### PR TITLE
[LMB-15] clear toload directory

### DIFF
--- a/data/db/toLoad/output000001.nq.gz
+++ b/data/db/toLoad/output000001.nq.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ca85ed33cf7d19bfd2f24aba20ec0c3fdbc89e1933769a46df1ef3882adaffae
-size 134396614


### PR DESCRIPTION
the to load directory wasn't added properly through git lfs and also wasn't necessary for the app to work properly