### PR TITLE
add fragmentation producer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Virtuoso files /data/db
 /data/publication-triplestore/*
 /data/db/*
+/data/ldes-feed/*
 /data/exports/*
 /data/toezicht-reports/*
 /data/db/virtuoso.ini

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -226,6 +226,13 @@ defmodule Dispatcher do
     forward conn, path, "http://adressenregister/"
   end
 
+  #################################################################
+  # LDES
+  #################################################################
+  get "/streams/ldes/*path" do
+    forward conn, path, "http://fragmentation-producer"
+  end
+
   #################
   # NOT FOUND
   #################

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -52,3 +52,9 @@ services:
     restart: "no"
   form-content:
     restart: "no"
+  fragmentation-producer:
+    restart: "no"
+    environment:
+      BASE_URL: "http://localhost/streams/ldes"
+    ports:
+      - "6666:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,3 +159,20 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+  fragmentation-producer:
+    image: redpencil/fragmentation-producer:0.4.0
+    restart: always
+    logging: *default-logging
+    labels:
+      - "logging=true"
+    environment:
+      BASE_URL: "https://lmb.lblod.info/streams/ldes"
+      FOLDER_DEPTH: 1
+      PAGE_RESOURCES_COUNT: 10
+      LDES_STREAM_PREFIX: "http://lmb.lblod.info/streams/ldes/"
+      TIME_TREE_RELATION_PATH: "http://www.w3.org/ns/prov#generatedAtTime"
+      CACHE_SIZE: 10
+      DATA_FOLDER: "/data"
+      ENABLE_AUTH: "false"
+    volumes:
+      - "./data/ldes-feed/:/data/"


### PR DESCRIPTION
This can be tested by first adding example data to a stream, e.g. a person stream with the following post:

```
curl --request POST \
  --url http://localhost:6666/person \
  --header 'Content-Type: text/turtle' \
  --data '<https://example.org/person/80325> a <http://xmlns.com/foaf/0.1/Person>;
        <http://xmlns.com/foaf/0.1/name> "John Lennon";
        <http://schema.org/birthDate> "1940-10-09"^^<http://www.w3.org/2001/XMLSchema#date>;
        <http://schema.org/spouse> <http://dbpedia.org/resource/Cynthia_Lennon>.'
```

It can then be fetched using:

```
curl --request GET \
  --url http://localhost:90/streams/ldes/person/1 \
  --header 'Accept: text/turtle' \
  --data '<https://example.org/person/80325> a <http://xmlns.com/foaf/0.1/Person>;
        <http://xmlns.com/foaf/0.1/name> "John Lennon";
        <http://schema.org/birthDate> "1940-10-09"^^<http://www.w3.org/2001/XMLSchema#date>;
        <http://schema.org/spouse> <http://dbpedia.org/resource/Cynthia_Lennon>.'
```

note that only the get route is exposed as putting instances on the stream is done only by internal services