### PR TITLE
monitor non mandataris instances and send them to LDES

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Virtuoso files /data/db
 /data/publication-triplestore/*
 /data/db/*
+/data/ldes-feed/*
 /data/exports/*
 /data/toezicht-reports/*
 /data/db/virtuoso.ini

--- a/config/delta/ldes.js
+++ b/config/delta/ldes.js
@@ -1,0 +1,15 @@
+export default [
+  {
+    match: {
+      subject: {},
+    },
+    callback: {
+      url: "http://ldes-delta-pusher/publish",
+      method: "POST",
+    },
+    options: {
+      resourceFormat: "v0.0.1",
+      gracePeriod: 10000,
+    },
+  },
+];

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -1,5 +1,4 @@
-import resource from './resource';
+import resource from "./resource";
+import ldes from "./ldes";
 
-export default [
-  ...resource
-];
+export default [...resource, ...ldes];

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -230,7 +230,7 @@ defmodule Dispatcher do
   # LDES
   #################################################################
   get "/streams/ldes/*path" do
-    forward conn, path, "http://fragmentation-producer"
+    forward conn, path, "http://ldes-backend"
   end
 
   #################

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -226,6 +226,13 @@ defmodule Dispatcher do
     forward conn, path, "http://adressenregister/"
   end
 
+  #################################################################
+  # LDES
+  #################################################################
+  get "/streams/ldes/*path" do
+    forward conn, path, "http://fragmentation-producer"
+  end
+
   #################
   # NOT FOUND
   #################

--- a/config/ldes-delta-pusher/dispatch.ts
+++ b/config/ldes-delta-pusher/dispatch.ts
@@ -1,0 +1,15 @@
+import { Changeset } from "../types";
+
+export default async function dispatch(changesets: Changeset[]) {
+  const subjects = new Set<string>();
+  for (const changeset of changesets) {
+    changeset.inserts.forEach((insert) => insert.subject.value);
+    changeset.deletes.forEach((del) => subjects.add(del.subject.value));
+  }
+
+  console.log(
+    `Received changeset(s) touching the following subjects:\n${[
+      ...subjects,
+    ].join("\n")}`
+  );
+}

--- a/config/ldes-delta-pusher/dispatch.ts
+++ b/config/ldes-delta-pusher/dispatch.ts
@@ -1,15 +1,6 @@
 import { Changeset } from "../types";
+import { handleRegularTypes } from "./handle-regular-types";
 
 export default async function dispatch(changesets: Changeset[]) {
-  const subjects = new Set<string>();
-  for (const changeset of changesets) {
-    changeset.inserts.forEach((insert) => insert.subject.value);
-    changeset.deletes.forEach((del) => subjects.add(del.subject.value));
-  }
-
-  console.log(
-    `Received changeset(s) touching the following subjects:\n${[
-      ...subjects,
-    ].join("\n")}`
-  );
+  handleRegularTypes(changesets);
 }

--- a/config/ldes-delta-pusher/handle-regular-types.ts
+++ b/config/ldes-delta-pusher/handle-regular-types.ts
@@ -1,0 +1,80 @@
+import { Changeset } from "../types";
+import { query } from "mu";
+import { publish } from "./publisher";
+import { log } from "./logger";
+
+type InterestingSubject = {
+  uri: string;
+  ldesType: string;
+};
+
+const regularTypesToLDESMapping = {
+  "http://data.vlaanderen.be/ns/mandaat#Fractie": "fractie",
+  "http://www.w3.org/ns/org#Membership": "lidmaatschap",
+  "http://data.vlaanderen.be/ns/mandaat#Mandaat": "mandaat",
+  "http://www.w3.org/ns/person#Person": "persoon",
+  "http://purl.org/dc/terms/PeriodOfTime": "periode",
+  "http://purl.org/dc/terms/Identifier": "identifier",
+  "http://data.vlaanderen.be/ns/persoon#Geboorte": "geboorte",
+};
+
+const keepRegularTypesQuery = async (subjects: string[]) => {
+  const types = Object.keys(regularTypesToLDESMapping);
+  const matches = await query(`
+      SELECT DISTINCT ?s ?type WHERE {
+        ?s a ?type .
+        VALUES ?type { ${types.map((type) => `<${type}>`).join(" ")} }
+        VALUES ?s { ${[...subjects]
+          .map((subject) => `<${subject}>`)
+          .join(" ")} }
+      }
+    `);
+  return matches.results.bindings
+    .map((binding) => {
+      const ldesType = regularTypesToLDESMapping[binding.type.value];
+      if (!ldesType) {
+        return null;
+      }
+      return { uri: binding.s.value, ldesType };
+    })
+    .filter((b) => !!b) as InterestingSubject[];
+};
+
+const keepRegularTypeSubjects = async (changesets: Changeset[]) => {
+  const subjects = new Set<string>();
+  for (const changeset of changesets) {
+    changeset.inserts.forEach((insert) => {
+      subjects.add(insert.subject.value);
+    });
+    changeset.deletes.forEach((del) => {
+      subjects.add(del.subject.value);
+    });
+  }
+
+  const allSubjects = [...subjects];
+  let subjectsToKeep: InterestingSubject[] = [];
+  const chunkSize = 1000;
+  for (let i = 0; i < allSubjects.length; i += chunkSize) {
+    const currentChunk = allSubjects.slice(i, i + chunkSize);
+    const toKeepForChunk = await keepRegularTypesQuery(currentChunk);
+    subjectsToKeep = subjectsToKeep.concat(toKeepForChunk);
+  }
+
+  return subjectsToKeep;
+};
+
+export const handleRegularTypes = async (changesets: Changeset[]) => {
+  const interestingSubjects = await keepRegularTypeSubjects(changesets);
+  log(
+    `Received changeset(s) touching the following interesting subjects:\n${JSON.stringify(
+      interestingSubjects
+    )}`,
+    "debug"
+  );
+
+  // do this serially to avoid overloading the stream endpoint
+  let current: InterestingSubject | undefined;
+  while ((current = interestingSubjects.pop())) {
+    await publish(current.ldesType, current.uri);
+  }
+};

--- a/config/ldes-delta-pusher/logger.ts
+++ b/config/ldes-delta-pusher/logger.ts
@@ -1,0 +1,11 @@
+const DEBUG = process.env.DEBUG === "true";
+
+export const log = (message: string, level = "log") => {
+  if (level === "log") {
+    console.log(message);
+  } else if (level === "error") {
+    console.error(message);
+  } else if (level === "debug" && DEBUG) {
+    console.log(`DEBUG: ${message}`);
+  }
+};

--- a/config/ldes-delta-pusher/publisher.ts
+++ b/config/ldes-delta-pusher/publisher.ts
@@ -1,0 +1,64 @@
+import { query, sparqlEscapeUri, sparqlEscape } from "mu";
+import { LDES_ENDPOINT } from "../config";
+import fetch from "node-fetch";
+import { log } from "./logger";
+
+const fetchSubjectData = async (subject: string) => {
+  const data = await query(`
+    CONSTRUCT {
+      <${subject}> ?p ?o .
+    } WHERE {
+      <${subject}> ?p ?o .
+    }
+  `);
+  return data.results.bindings.map(bindingToTriple).join("\n");
+};
+
+async function sendLDESRequest(type: string, body: string) {
+  log(`Sending data to LDES endpoint ${LDES_ENDPOINT}/${type}`, "debug");
+  await fetch(`${LDES_ENDPOINT}/${type}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "text/turtle",
+    },
+    // somehow the xsd prefix isn't included bit is used in the types...
+    body: `@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n${body}`,
+  });
+}
+
+const datatypeNames = {
+  "http://www.w3.org/2001/XMLSchema#dateTime": "dateTime",
+  "http://www.w3.org/2001/XMLSchema#date": "date",
+  "http://www.w3.org/2001/XMLSchema#decimal": "decimal",
+  "http://www.w3.org/2001/XMLSchema#integer": "int",
+  "http://www.w3.org/2001/XMLSchema#float": "float",
+  "http://www.w3.org/2001/XMLSchema#boolean": "bool",
+};
+
+const sparqlEscapeObject = (bindingObject): string => {
+  const escapeType = datatypeNames[bindingObject.datatype] || "string";
+  return bindingObject.type === "uri"
+    ? sparqlEscapeUri(bindingObject.value)
+    : sparqlEscape(bindingObject.value, escapeType);
+};
+
+const bindingToTriple = (binding) =>
+  `${sparqlEscapeUri(binding.s.value)} ${sparqlEscapeUri(
+    binding.p.value
+  )} ${sparqlEscapeObject(binding.o)} .`;
+
+/**
+ * Publish the currently known info for the given subject URI to the LDES endpoint of the given type
+ * @param ldesType the name of the LDES endpoint to publish to (e.g. "person")
+ * @param subject the uri of the subject to fetch data for and publish
+ */
+export const publish = async (ldesType: string, subject: string) => {
+  const data = await fetchSubjectData(subject);
+  log(`Publishing data for subject ${subject}:\n${data}`, "debug");
+  await sendLDESRequest(ldesType, data).catch((e) => {
+    log(
+      `Error publishing data for subject ${subject} to LDES endpoint ${ldesType}: ${e}`,
+      "error"
+    );
+  });
+};

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -52,3 +52,9 @@ services:
     restart: "no"
   form-content:
     restart: "no"
+  fragmentation-producer:
+    restart: "no"
+    environment:
+      BASE_URL: "http://localhost/streams/ldes"
+    ports:
+      - "6666:80"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -52,8 +52,12 @@ services:
     restart: "no"
   form-content:
     restart: "no"
+  adressenregister:
+    restart: "no"
   ldes-delta-pusher:
     restart: "no"
+    environment:
+      DEBUG: "true"
   ldes-backend:
     restart: "no"
     environment:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -52,7 +52,9 @@ services:
     restart: "no"
   form-content:
     restart: "no"
-  fragmentation-producer:
+  ldes-delta-pusher:
+    restart: "no"
+  ldes-backend:
     restart: "no"
     environment:
       BASE_URL: "http://localhost/streams/ldes"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,10 +166,12 @@ services:
   ldes-delta-pusher:
     image: redpencil/ldes-delta-pusher:latest
     environment:
-      LDES_ENDPOINT: "http://ldes-backend/"
+      LDES_ENDPOINT: "http://ldes-backend"
     volumes:
       - ./config/ldes-delta-pusher/:/config/
     restart: always
+    links:
+      - virtuoso:database
   ldes-backend:
     image: redpencil/fragmentation-producer:0.4.0
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,3 +159,20 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+  fragmentation-producer:
+    image: redpencil/fragmentation-producer:0.4.0
+    restart: always
+    logging: *default-logging
+    labels:
+      - "logging=true"
+    environment:
+      BASE_URL: "https://lmb.lblod.info/streams/ldes"
+      FOLDER_DEPTH: 1
+      PAGE_RESOURCES_COUNT: 10
+      LDES_STREAM_PREFIX: "http://lmb.lblod.info/streams/ldes/"
+      TIME_TREE_RELATION_PATH: "http://www.w3.org/ns/prov#generatedAtTime"
+      CACHE_SIZE: 10
+      DATA_FOLDER: "/data"
+      ENABLE_AUTH: "false"
+    volumes:
+      - "./data/ldes-feed/:/data/"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,7 +159,18 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
-  fragmentation-producer:
+
+  ##############################################################################
+  # LDES
+  ##############################################################################
+  ldes-delta-pusher:
+    image: redpencil/ldes-delta-pusher:latest
+    environment:
+      LDES_ENDPOINT: "http://ldes-backend/"
+    volumes:
+      - ./config/ldes-delta-pusher/:/config/
+    restart: always
+  ldes-backend:
     image: redpencil/fragmentation-producer:0.4.0
     restart: always
     logging: *default-logging


### PR DESCRIPTION
```
ldes-delta-pusher-1  | DEBUG: Publishing data for subject http://data.lblod.info/id/mandaten/f990dcf131e3c0647a7b3b48a6c3d0d516350023567145701824d2c59ce01741:
ldes-delta-pusher-1  | <http://data.lblod.info/id/mandaten/f990dcf131e3c0647a7b3b48a6c3d0d516350023567145701824d2c59ce01741> <http://data.vlaanderen.be/ns/mandaat#aantalHouders> "12"^^xsd:integer .
ldes-delta-pusher-1  | <http://data.lblod.info/id/mandaten/f990dcf131e3c0647a7b3b48a6c3d0d516350023567145701824d2c59ce01741> <http://www.w3.org/ns/org#role> <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000011> .
ldes-delta-pusher-1  | <http://data.lblod.info/id/mandaten/f990dcf131e3c0647a7b3b48a6c3d0d516350023567145701824d2c59ce01741> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://data.vlaanderen.be/ns/mandaat#Mandaat> .
ldes-delta-pusher-1  | <http://data.lblod.info/id/mandaten/f990dcf131e3c0647a7b3b48a6c3d0d516350023567145701824d2c59ce01741> <http://mu.semte.ch/vocabularies/core/uuid> """f990dcf131e3c0647a7b3b48a6c3d0d516350023567145701824d2c59ce01741""" .
ldes-delta-pusher-1  | DEBUG: Sending data to LDES endpoint http://ldes-backend/mandaat
```

which results in the mandaat/1 page being created and updated with the correct information when editing mandaten in the frontend.