### PR TITLE
bump resources over cache issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
     restart: always
     logging: *default-logging
   resource:
-    image: semtech/mu-cl-resources:feature-optionally-accept-strange-resource-types
+    image: semtech/mu-cl-resources:1.23.0
     environment:
       CACHE_CLEAR_PATH: "http://cache/.mu/clear-keys"
     volumes:


### PR DESCRIPTION
used to be on https://github.com/mu-semtech/mu-cl-resources/tree/feature/optionally-accept-strange-resource-types, which is 22 behind master. Without this change, a created bestuursorgaan in periode did not appear in the included list of an orgaan's tijdsspecialisaties