### PR TITLE
allow read access for vendors through authenticated sparql endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,11 +183,11 @@ Vendors can access the sparql endpoint through the `/vendor/sparql` endpoint. Th
 
 In this request the `organization` property contains the URI of the bestuurseenheid they want to have access for. They provide their own URI in the `publisher.uri` field and their key in the `publisher.key` field.
 
-New publishers can be registered using a migration e.g. like [this one](./config/migrations/2024/20240319110700-add-vendor-login.sparql). This migration links the vendor's user to the organizations it can act on behalf of and adds the right roles to their account. HOWEVER you should NEVER add a key for the vendor in this migration. The key should be added using a manual query/migration on the production server, e.g. [like this](./queries/vendor-access/add-vendor-key.sparql). It should NEVER be put in the git repo.
+New publishers can be registered using a migration e.g. like the [add-vendor-login.sparql](./config/migrations/2024/20240319110700-add-vendor-login.sparql) on in this repo. This migration links the vendor's user to the organizations it can act on behalf of and adds the right roles to their account. HOWEVER you should NEVER add a key for the vendor in this migration. The key should be added using a manual query/migration on the production server, e.g. the [add-vendor-key.sparql](./queries/vendor-access/add-vendor-key.sparql) example query in this repo. It should NEVER be put in the git repo.
 
 Once the vendor is logged in, they receive a token in their cookie, like is done with the normal login service and they can access the `/vendor/sparql` endpoint using that cookie. This endpoint acts exactly like the normal sparql endpoint, but also [verifies](./config/sparql-authorization-wrapper/filter.js) that the user can act on behalf of an organization (as a secondary precaution after the login service).
 
-An example request to the vendor's sparql endpoint could be a POST with Content-Type: application/x-www-form-urlencoded and body `query=SELECT+DISTINCT+?s+?p+?o+WHERE+{+?s+?p+?o+.+}+LIMIT+10`.
+An example request to the vendor's sparql endpoint could be a POST with Content-Type: application/x-www-form-urlencoded and body `query=SELECT+DISTINCT+?s+?p+?o+WHERE+{+?s+?p+?o+.+}+LIMIT+10` (so the url encoded query).
 
 ## Legacy
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,30 @@ drc logs form-content -f
 
 This application uses LDES to share information with other applications, like the Vlaamse Mandatendatabank and Gelinkt Notuleren. Read more about it [here](docs/LDES.md).
 
+## Vendor Sparql Access
+
+Vendors can access the sparql endpoint through the `/vendor/sparql` endpoint. This is secured through the [lblod/vendor-login-service](https://github.com/lblod/vendor-login-service). They need to log in first using a POST request to `/vendor/login` with a body like this:
+
+```
+{
+  "organization": "http://data.lblod.info/id/bestuurseenheden/d769b4b9411ad25f67c1d60b0a403178e24a800e1671fb3258280495011d8e18",
+  "publisher": {
+    "uri": "http://data.lblod.info/vendors/c5da766f-f1a6-426a-9a4d-36b96a855e18",
+    "key": "my super secret key that i should replace"
+  }
+}
+```
+
+In this request the `organization` property contains the URI of the bestuurseenheid they want to have access for. They provide their own URI in the `publisher.uri` field and their key in the `publisher.key` field.
+
+New publishers can be registered using a migration e.g. like [this one](./config/migrations/2024/20240319110700-add-vendor-login.sparql). This migration links the vendor's user to the organizations it can act on behalf of and adds the right roles to their account. HOWEVER you should NEVER add a key for the vendor in this migration. The key should be added using a manual query/migration on the production server, e.g. [like this](./queries/vendor-access/add-vendor-key.sparql). It should NEVER be put in the git repo.
+
+Once the vendor is logged in, they receive a token in their cookie, like is done with the normal login service and they can access the `/vendor/sparql` endpoint using that cookie. This endpoint acts exactly like the normal sparql endpoint, but also [verifies](./config/sparql-authorization-wrapper/filter.js) that the user can act on behalf of an organization (as a secondary precaution after the login service).
+
+An example request to the vendor's sparql endpoint could be a POST with Content-Type: application/x-www-form-urlencoded and body `query=SELECT+DISTINCT+?s+?p+?o+WHERE+{+?s+?p+?o+.+}+LIMIT+10`.
+
+## Legacy
+
 > [!CAUTION]
 > The info below is not up to date anymore. These services are inherited from [loket](https://github.com/lblod/app-digitaal-loket), these aren't used anymore, but will be introduced again in the near future.
 

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -64,19 +64,6 @@ defmodule Acl.UserGroups.Config do
     }
   end
 
-  defp can_access_automatic_submission() do
-    %AccessByQuery{
-      vars: [],
-      query: "PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-        PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-        SELECT DISTINCT ?session_group ?session_role WHERE {
-          <SESSION_ID> ext:sessionGroup/mu:uuid ?session_group;
-                       ext:sessionRole ?session_role.
-          FILTER( ?session_role = \"LoketLB-vendorManagementGebruiker\" )
-        }"
-      }
-  end
-
   defp access_for_vendor_sparql() do
     %AccessByQuery{
       vars: ["session_group", "session_role"],
@@ -272,31 +259,6 @@ defmodule Acl.UserGroups.Config do
           }
         ]
       },
-
-      # // VENDOR MANAGEMENT
-      %GroupSpec{
-        name: "o-toezicht-vendor-management-rwf",
-        useage: [:read, :write, :read_for_write],
-        access: can_access_automatic_submission(),
-        graphs: [ %GraphSpec{
-                    graph: "http://mu.semte.ch/graphs/automatic-submission",
-                    constraint: %ResourceConstraint{
-                      resource_types: [
-                        "http://mu.semte.ch/vocabularies/ext/Vendor",
-                        "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid"
-                      ] } },
-                   %GraphSpec{
-                    graph: "http://mu.semte.ch/graphs/authenticated/public",
-                    constraint: %ResourceConstraint{
-                       resource_types: [
-                         "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid",
-                       ],
-                       predicates: %NoPredicates{
-                         except: [
-                           "http://mu.semte.ch/vocabularies/ext/viewOnlyModules"
-                         ] } } }
-                  ] },
-
       # // Vendor API
       %GroupSpec{
         name: "o-vendor-api-r",

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -8,6 +8,31 @@ alias Acl.GroupSpec, as: GroupSpec
 alias Acl.GroupSpec.GraphCleanup, as: GraphCleanup
 
 defmodule Acl.UserGroups.Config do
+  defp mandaat_types() do
+    [
+      "http://data.lblod.info/vocabularies/contacthub/AgentInPositie",
+      "http://data.vlaanderen.be/ns/mandaat#Fractie",
+      "http://data.vlaanderen.be/ns/persoon#Geboorte",
+      "http://www.w3.org/ns/org#Membership",
+      "http://data.vlaanderen.be/ns/besluit#Bestuursorgaan",
+      "http://data.vlaanderen.be/ns/mandaat#Mandataris",
+      "http://data.vlaanderen.be/ns/mandaat#Mandaat",
+      "http://www.w3.org/ns/org#Post",
+      "http://www.w3.org/ns/person#Person",
+      "http://www.w3.org/ns/adms#Identifier",
+      "http://purl.org/dc/terms/PeriodOfTime",
+      "http://mu.semte.ch/vocabularies/ext/Form",
+      "http://mu.semte.ch/vocabularies/ext/Extension",
+      "http://mu.semte.ch/vocabularies/ext/Installatievergadering",
+      "http://mu.semte.ch/vocabularies/ext/InstallatievergaderingStatus",
+      "http://data.vlaanderen.be/ns/mandaat#RechtstreekseVerkiezing",
+      "http://data.vlaanderen.be/ns/mandaat#Kandidatenlijst",
+      "http://mu.semte.ch/vocabularies/ext/KandidatenlijstLijsttype",
+      "http://data.vlaanderen.be/ns/mandaat#Verkiezingsresultaat",
+      "http://mu.semte.ch/vocabularies/ext/VerkiezingsresultaatGevolgCode"
+    ]
+  end
+
   defp access_by_role(group_string) do
     %AccessByQuery{
       vars: ["session_group", "session_role"],
@@ -37,6 +62,36 @@ defmodule Acl.UserGroups.Config do
                        ext:sessionRole ?session_role.
         }"
     }
+  end
+
+  defp can_access_automatic_submission() do
+    %AccessByQuery{
+      vars: [],
+      query: "PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+        PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+        SELECT DISTINCT ?session_group ?session_role WHERE {
+          <SESSION_ID> ext:sessionGroup/mu:uuid ?session_group;
+                       ext:sessionRole ?session_role.
+          FILTER( ?session_role = \"LoketLB-vendorManagementGebruiker\" )
+        }"
+      }
+  end
+
+  defp access_for_vendor_sparql() do
+    %AccessByQuery{
+      vars: ["session_group", "session_role"],
+      query: sparql_query_for_access_vendor_sparql()
+    }
+  end
+
+  defp sparql_query_for_access_vendor_sparql() do
+    " PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+      PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/>
+      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+      SELECT DISTINCT ?session_group ?session_role WHERE {
+        <SESSION_ID> muAccount:canActOnBehalfOf/mu:uuid ?session_group;
+                     muAccount:account/ext:sessionRole ?session_role.
+      } "
   end
 
   def user_groups do
@@ -162,28 +217,7 @@ defmodule Acl.UserGroups.Config do
           %GraphSpec{
             graph: "http://mu.semte.ch/graphs/organizations/",
             constraint: %ResourceConstraint{
-              resource_types: [
-                "http://data.lblod.info/vocabularies/contacthub/AgentInPositie",
-                "http://data.vlaanderen.be/ns/mandaat#Fractie",
-                "http://data.vlaanderen.be/ns/persoon#Geboorte",
-                "http://www.w3.org/ns/org#Membership",
-                "http://data.vlaanderen.be/ns/besluit#Bestuursorgaan",
-                "http://data.vlaanderen.be/ns/mandaat#Mandataris",
-                "http://data.vlaanderen.be/ns/mandaat#Mandaat",
-                "http://www.w3.org/ns/org#Post",
-                "http://www.w3.org/ns/person#Person",
-                "http://www.w3.org/ns/adms#Identifier",
-                "http://purl.org/dc/terms/PeriodOfTime",
-                "http://mu.semte.ch/vocabularies/ext/Form",
-                "http://mu.semte.ch/vocabularies/ext/Extension",
-                "http://mu.semte.ch/vocabularies/ext/Installatievergadering",
-                "http://mu.semte.ch/vocabularies/ext/InstallatievergaderingStatus",
-                "http://data.vlaanderen.be/ns/mandaat#RechtstreekseVerkiezing",
-                "http://data.vlaanderen.be/ns/mandaat#Kandidatenlijst",
-                "http://mu.semte.ch/vocabularies/ext/KandidatenlijstLijsttype",
-                "http://data.vlaanderen.be/ns/mandaat#Verkiezingsresultaat",
-                "http://mu.semte.ch/vocabularies/ext/VerkiezingsresultaatGevolgCode"
-              ]
+              resource_types: mandaat_types()
             }
           }
         ]
@@ -196,29 +230,7 @@ defmodule Acl.UserGroups.Config do
           %GraphSpec{
             graph: "http://mu.semte.ch/graphs/organizations/",
             constraint: %ResourceConstraint{
-              resource_types: [
-                "http://data.lblod.info/vocabularies/contacthub/AgentInPositie",
-                "http://data.vlaanderen.be/ns/mandaat#Fractie",
-                "http://data.vlaanderen.be/ns/persoon#Geboorte",
-                "http://www.w3.org/ns/org#Membership",
-                "http://data.vlaanderen.be/ns/mandaat#Mandataris",
-                "http://data.vlaanderen.be/ns/mandaat#Mandaat",
-                "http://www.w3.org/ns/org#Post",
-                "http://data.vlaanderen.be/ns/besluit#Bestuursorgaan",
-                "http://www.w3.org/ns/person#Person",
-                "http://www.w3.org/ns/adms#Identifier",
-                "http://www.w3.org/ns/activitystreams#Tombstone",
-                "http://purl.org/dc/terms/PeriodOfTime",
-                "http://mu.semte.ch/vocabularies/ext/Form",
-                "http://mu.semte.ch/vocabularies/ext/Extension",
-                "http://mu.semte.ch/vocabularies/ext/Installatievergadering",
-                "http://mu.semte.ch/vocabularies/ext/InstallatievergaderingStatus",
-                "http://data.vlaanderen.be/ns/mandaat#RechtstreekseVerkiezing",
-                "http://data.vlaanderen.be/ns/mandaat#Kandidatenlijst",
-                "http://mu.semte.ch/vocabularies/ext/KandidatenlijstLijsttype",
-                "http://data.vlaanderen.be/ns/mandaat#Verkiezingsresultaat",
-                "http://mu.semte.ch/vocabularies/ext/VerkiezingsresultaatGevolgCode"
-              ]
+              resource_types: mandaat_types()
             }
           }
         ]
@@ -260,6 +272,42 @@ defmodule Acl.UserGroups.Config do
           }
         ]
       },
+
+      # // VENDOR MANAGEMENT
+      %GroupSpec{
+        name: "o-toezicht-vendor-management-rwf",
+        useage: [:read, :write, :read_for_write],
+        access: can_access_automatic_submission(),
+        graphs: [ %GraphSpec{
+                    graph: "http://mu.semte.ch/graphs/automatic-submission",
+                    constraint: %ResourceConstraint{
+                      resource_types: [
+                        "http://mu.semte.ch/vocabularies/ext/Vendor",
+                        "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid"
+                      ] } },
+                   %GraphSpec{
+                    graph: "http://mu.semte.ch/graphs/authenticated/public",
+                    constraint: %ResourceConstraint{
+                       resource_types: [
+                         "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid",
+                       ],
+                       predicates: %NoPredicates{
+                         except: [
+                           "http://mu.semte.ch/vocabularies/ext/viewOnlyModules"
+                         ] } } }
+                  ] },
+
+      # // Vendor API
+      %GroupSpec{
+        name: "o-vendor-api-r",
+        useage: [:read],
+        access: access_for_vendor_sparql(),
+        graphs: [ %GraphSpec{
+            graph: "http://mu.semte.ch/graphs/organizations/",
+            constraint: %ResourceConstraint{
+              resource_types: mandaat_types()
+            }
+          } ] },
 
       # // CLEANUP
       #

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -312,6 +312,28 @@ defmodule Dispatcher do
     forward(conn, path, "http://ldes-backend")
   end
 
+  #################################################################
+  # Vendor Login for SPARQL endpoint
+  #################################################################
+
+  post "/vendor/login/*path" do
+    Proxy.forward conn, path, "http://vendor-login/sessions"
+  end
+
+  delete "/vendor/logout" do
+    Proxy.forward conn, [], "http://vendor-login/sessions/current"
+  end
+
+  #################################################################
+  # Vendor SPARQL endpoint
+  #################################################################
+
+  # Not only POST. SPARQL via GET is also allowed.
+  match "/vendor/sparql" do
+    Proxy.forward conn, [], "http://sparql-authorization-wrapper/sparql"
+  end
+
+
   #################
   # NOT FOUND
   #################

--- a/config/migrations/2024/20240319110700-add-vendor-login.sparql
+++ b/config/migrations/2024/20240319110700-add-vendor-login.sparql
@@ -1,0 +1,17 @@
+PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX bestuurseenheid: <http://data.lblod.info/id/bestuurseenheden/>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/automatic-submission> {
+   <http://data.lblod.info/vendors/c5da766f-f1a6-426a-9a4d-36b96a855e18> a foaf:Agent, ext:Vendor ;
+    foaf:name "Demo Vendor" ;
+    muAccount:canActOnBehalfOf bestuurseenheid:d769b4b9411ad25f67c1d60b0a403178e24a800e1671fb3258280495011d8e18 ,
+                               bestuurseenheid:5d6cc695e6c2082ca219baf425c61e8fc8ea25ec5a11187f1d96863266adcd64 ;
+    <http://mu.semte.ch/vocabularies/ext/sessionRole>	"LoketLB-mandaatGebruiker" ,
+		                                                  "LoketLB-leidinggevendenGebruiker" ;
+    mu:uuid "c5da766f-f1a6-426a-9a4d-36b96a855e18".
+  }
+}

--- a/config/sparql-authorization-wrapper/filter.js
+++ b/config/sparql-authorization-wrapper/filter.js
@@ -1,0 +1,33 @@
+import * as mu from 'mu';
+import * as mas from '@lblod/mu-auth-sudo';
+
+export async function isAuthorized(sessionUri) {
+  const checkSessionQuery = `
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+    PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/>
+    PREFIX wotSec: <https://www.w3.org/2019/wot/security#>
+    PREFIX lblodAuth: <http://lblod.data.gift/vocabularies/authentication/>
+    PREFIX pav: <http://purl.org/pav/>
+    PREFIX session: <http://mu.semte.ch/vocabularies/session/>
+    PREFIX oslc: <http://open-services.net/ns/core#>
+    PREFIX dct: <http://purl.org/dc/terms/>
+
+    SELECT DISTINCT ?uuid ?created ?account {
+      GRAPH ?g {
+        ${mu.sparqlEscapeUri(sessionUri)}
+          a session:Session ;
+          mu:uuid ?uuid ;
+          dct:created ?created ;
+          muAccount:account ?account ;
+          muAccount:canActOnBehalfOf ?org .
+      }
+    }
+  `;
+  const response = await mas.querySudo(checkSessionQuery);
+  // We want exactly one result, only one session should exist at a certain time.
+  const exists = response.results?.bindings?.length === 1;
+  return exists;
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -64,3 +64,7 @@ services:
       BASE_URL: "http://localhost/streams/ldes"
     ports:
       - "6666:80"
+  vendor-login:
+    restart: "no"
+  sparql-authorization-wrapper:
+    restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     restart: always
     logging: *default-logging
   database:
-    image: semtech/mu-authorization:feature-service-roam-r1.1
+    image: semtech/mu-authorization:0.6.0-beta.8
     environment:
       MU_SPARQL_ENDPOINT: "http://virtuoso:8890/sparql"
       DATABASE_OVERLOAD_RECOVERY: "true"
@@ -170,6 +170,8 @@ services:
     volumes:
       - ./config/ldes-delta-pusher/:/config/
     restart: always
+    labels:
+      - "logging=true"
     links:
       - virtuoso:database
   ldes-backend:
@@ -189,3 +191,16 @@ services:
       ENABLE_AUTH: "false"
     volumes:
       - "./data/ldes-feed/:/data/"
+  ##############################################################################
+  # VENDOR ENDPOINTS
+  ##############################################################################
+  vendor-login:
+    image: lblod/vendor-login-service:1.0.0
+    restart: always
+    logging: *default-logging
+  sparql-authorization-wrapper:
+    image: lblod/sparql-authorization-wrapper-service:1.0.0
+    volumes:
+      - ./config/sparql-authorization-wrapper:/config
+    restart: always
+    logging: *default-logging

--- a/queries/vendor-access/add-vendor-key.sparql
+++ b/queries/vendor-access/add-vendor-key.sparql
@@ -1,0 +1,12 @@
+PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX bestuurseenheid: <http://data.lblod.info/id/bestuurseenheden/>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/automatic-submission> {
+   <http://data.lblod.info/vendors/c5da766f-f1a6-426a-9a4d-36b96a855e18> muAccount:key "my super secret key that i should replace" .
+  }
+}
+


### PR DESCRIPTION
This adds an authenticated sparql endpoint that vendors can use to have read access to all the data visible to an organization.

I've attached a bruno collection that can be used to test this service.

Note that the sparql query i used in bruno uses the plain sparql syntax which isn't supported in the standard mu-auth yet (see https://github.com/mu-semtech/mu-authorization/pull/20/files), you can replace it by a query param with the url encoded sparql query instead.

[vendor sparql.json](https://github.com/lblod/app-lokaal-mandatenbeheer/files/14652060/vendor.sparql.json)
