### PR TITLE
LMB-365: Duplication in ldes

### DIFF
--- a/config/ldes-delta-pusher/dispatch.ts
+++ b/config/ldes-delta-pusher/dispatch.ts
@@ -3,6 +3,21 @@ import { handleRegularTypes } from "./handle-regular-types";
 import { handleMandatarisType } from "./handle-mandataris-type";
 
 export default async function dispatch(changesets: Changeset[]) {
-  handleRegularTypes(changesets);
-  handleMandatarisType(changesets);
+  const nonHistoryChangesets = filterOutHistoryChanges(changesets);
+
+  handleRegularTypes(nonHistoryChangesets);
+  handleMandatarisType(nonHistoryChangesets);
+}
+
+function filterOutHistoryChanges(changesets: Changeset[]) {
+  const doesNotStartWithHistoryUri = (quad) => !quad.graph.value.startsWith('http://mu.semte.ch/graphs/formHistory');
+
+  return changesets.map(change => {
+    const { inserts, deletes } = change;
+
+    return {
+      inserts: inserts.filter(doesNotStartWithHistoryUri),
+      deletes: deletes.filter(doesNotStartWithHistoryUri),
+    }
+  })
 }

--- a/config/ldes-delta-pusher/publisher.ts
+++ b/config/ldes-delta-pusher/publisher.ts
@@ -8,7 +8,12 @@ const fetchSubjectData = async (subject: string) => {
     CONSTRUCT {
       <${subject}> ?p ?o .
     } WHERE {
-      <${subject}> ?p ?o .
+      GRAPH ?g {
+        <${subject}> ?p ?o .
+      }
+      FILTER NOT EXISTS {
+        ?g a <http://mu.semte.ch/vocabularies/ext/FormHistory> .
+      }
     }
   `);
   return data.results.bindings.map(bindingToTriple).join("\n");


### PR DESCRIPTION
## Issue
 LMB-365

## Description
Items in LDES contain the history information and are added twice: once for the history information being added and once for the original change.

## Test
1. Open a fraction
2. Change the label using the fraction form
3. wait 10 sec
4. Look in `data/ldes-feed/..` see if the label is there only once and the previous values aren't present in the latest version