### PR TITLE
add migration to fix fractietype of onafhankelijke fracties

### DIFF
--- a/config/migrations/2024/20240412091121-fix-onafhankelijke-fractie.sparql
+++ b/config/migrations/2024/20240412091121-fix-onafhankelijke-fractie.sparql
@@ -1,0 +1,21 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX fractieType: <http://data.vlaanderen.be/id/concept/Fractietype/>
+PREFIX regorg: <https://www.w3.org/ns/regorg#>
+
+DELETE {
+	GRAPH ?g {
+		?fractie ext:isFractietype fractieType:Samenwerkingsverband.
+	}
+}
+INSERT {
+	GRAPH ?g {
+		?fractie ext:isFractietype fractieType:Onafhankelijk.
+	}
+}
+WHERE {
+	GRAPH ?g {
+		?fractie ext:isFractietype fractieType:Samenwerkingsverband.
+		?fractie regorg:legalName ?name.
+	}
+	FILTER regex(?name, "onafhank", "i").
+}


### PR DESCRIPTION
This can be checked if you go to the ember debug window and check if the onafhankelijke fractie in e.g. Gemeente Aalst or OCMW Aarschot is effectively of the fractietype onafhankelijk.