### PR TITLE
add fake rrns, keep query that was used to generate kieslijst example for aalter and aarschot

### DIFF
--- a/config/migrations/2024/20240412135700-add-fake-rrn.sparql
+++ b/config/migrations/2024/20240412135700-add-fake-rrn.sparql
@@ -1,0 +1,110 @@
+PREFIX ids: <http://data.lblod.info/id/identificatoren/>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX person: <http://www.w3.org/ns/person#>
+
+INSERT {
+  GRAPH ?g {
+    ?person a person:Person.
+    ?person adms:identifier ?id.
+    ?id a adms:Identifier .
+    ?id mu:uuid ?uuid .
+    ?id skos:notation ?rrn .
+  }
+} WHERE {
+  GRAPH ?g {
+   ?person a person:Person.
+  }
+  VALUES (?id ?uuid ?person ?rrn) {
+  ( ids:4b9398f9-55a7-42ee-821e-eab565ed4bac "4b9398f9-55a7-42ee-821e-eab565ed4bac" <http://data.lblod.info/id/personen/9d4f8fc1-a29a-4d27-b9a8-06338a349075> "79058240642" )
+  ( ids:eb8f5476-3fb9-4b1e-b69e-db9545e4a321 "eb8f5476-3fb9-4b1e-b69e-db9545e4a321" <http://data.lblod.info/id/personen/f94d208c3414ef88a4c87f8a031f94c8b4c5143062564d6668c79ba6f525f89e> "20220147827" )
+  ( ids:1db3f6d9-3fac-44e5-9750-ce27521932f7 "1db3f6d9-3fac-44e5-9750-ce27521932f7" <http://data.lblod.info/id/personen/a06804341bf49219fb1a2b64b49c5fb619209e95ffb7d957d00590564baefbcf> "31850945238" )
+  ( ids:91ae130d-22b4-43a0-bf97-5c30dfea7366 "91ae130d-22b4-43a0-bf97-5c30dfea7366" <http://data.lblod.info/id/personen/1163a9807bcc4c9e4c6d4daab821550f8aa038fa3c629a0b71e6e1b1f951679d> "52355940640" )
+  ( ids:797e3d19-069f-4bf6-b889-baae40590f46 "797e3d19-069f-4bf6-b889-baae40590f46" <http://data.lblod.info/id/personen/c6aa242a51436c14332f824ee7f3a3addabeac83971dc9e671ef1b3cdd942b7e> "43803937139" )
+  ( ids:ad54fd07-e292-42b9-8cf4-fd9fb03f20f5 "ad54fd07-e292-42b9-8cf4-fd9fb03f20f5" <http://data.lblod.info/id/personen/f5979b66f11984b5d21da224a3ce9fddda42e0c883fa1cdab8e1ff6c19179e3a> "56541865243" )
+  ( ids:f492714f-46d5-4435-8356-b9d7fa5afd6a "f492714f-46d5-4435-8356-b9d7fa5afd6a" <http://data.lblod.info/id/personen/452faf807f9ea425bf780a9d9f3308b8e321f71c1c76b0205683a0e6fcc1b6d4> "25654362034" )
+  ( ids:fb58a591-4d0e-4b96-8a4e-2667a31edc37 "fb58a591-4d0e-4b96-8a4e-2667a31edc37" <http://data.lblod.info/id/personen/6b764932bbb1526516ab4f7b8e10f8cb69d946c9dc32deb21c82aea21aac1d30> "76678219249" )
+  ( ids:5b2b9824-feb8-46df-a9f3-c35229d29943 "5b2b9824-feb8-46df-a9f3-c35229d29943" <http://data.lblod.info/id/personen/96d05aaa4a51521d0f404ebff8ea008da99f1e1aa374336e82d2baf45543c8c7> "39416672847" )
+  ( ids:f2fa4ac7-7d2e-406d-b813-e53af1e4392f "f2fa4ac7-7d2e-406d-b813-e53af1e4392f" <http://data.lblod.info/id/personen/893b73b7-cd12-4180-b1c6-142cc48787da> "81438353238" )
+  ( ids:4293ebd3-1303-40f9-83d9-9d12266b6202 "4293ebd3-1303-40f9-83d9-9d12266b6202" <http://data.lblod.info/id/personen/65fac73debbbb4c3bf0292ddb1fc23432da3322df512d86220ef1362950f939a> "12772432635" )
+  ( ids:4574fe9e-0d2e-45ac-8605-72a905a1f793 "4574fe9e-0d2e-45ac-8605-72a905a1f793" <http://data.lblod.info/id/personen/004611f390fdce566eedf5b88932748434ac60eaa577a70df2668a2e01f84842> "39415291237" )
+  ( ids:b4efc967-1c15-4e75-9184-da4d1e7bacba "b4efc967-1c15-4e75-9184-da4d1e7bacba" <http://data.lblod.info/id/personen/14aa815b-8dbb-40eb-afe9-28b629dda0b2> "10724068332" )
+  ( ids:055b9ca3-0eee-4019-97d9-7e5e4320c16a "055b9ca3-0eee-4019-97d9-7e5e4320c16a" <http://data.lblod.info/id/personen/94bc4ad0cc6b15b6c0a61286330c7df6785b281b051a1c258ab6f44eb0ef6681> "98532980550" )
+  ( ids:a8791b10-99bf-468d-8805-7a56ac5c0cb7 "a8791b10-99bf-468d-8805-7a56ac5c0cb7" <http://data.lblod.info/id/personen/69613091670ca7d7d950c7dc62425c0aca080c946c824ddd8c5101bd7ba75011> "30897231034" )
+  ( ids:8070e567-a5bb-495b-9d6c-ee1e06869af0 "8070e567-a5bb-495b-9d6c-ee1e06869af0" <http://data.lblod.info/id/personen/d6d5faf0c03f87d1f9d8a9d7cfe57ab6f201cd1dde23be755670bb844d0faaf2> "85983437048" )
+  ( ids:84b3708a-8692-4bd6-ab8e-8860e45990e4 "84b3708a-8692-4bd6-ab8e-8860e45990e4" <http://data.lblod.info/id/personen/6f246050966a1546cacd95e9c552b94307d4c82f77b3c34800e7a10bf3230784> "66042664136" )
+  ( ids:6beabe2f-23a5-43fa-8011-94f871333677 "6beabe2f-23a5-43fa-8011-94f871333677" <http://data.lblod.info/id/personen/b241650c5c1bbdf6afc1fb2a3703a0a607c9ce5cd5fe0aa1ab6e29a894373605> "99129293954" )
+  ( ids:35b7cf4a-8e4a-46e4-949e-f6bc8d88c704 "35b7cf4a-8e4a-46e4-949e-f6bc8d88c704" <http://data.lblod.info/id/personen/a2fc2241e47774cbfb6aa4bb5dcc06cdfceee2784364b6e2b5e0f0cc410e143e> "70887839556" )
+  ( ids:e2aa8f14-78e1-4c75-963a-d634e6742a21 "e2aa8f14-78e1-4c75-963a-d634e6742a21" <http://data.lblod.info/id/personen/e3577bd06c66bbf0cf137698a52eda3e31cb0fa8e879a8eaaf1d713982fec31f> "92992360546" )
+  ( ids:bd0e8a26-10fe-4458-9a64-568817b580e1 "bd0e8a26-10fe-4458-9a64-568817b580e1" <http://data.lblod.info/id/personen/b24d01a608712042211aa4f920190f689b2a26604076b92d0fab15d22c03a317> "81494592144" )
+  ( ids:5b38bd64-8e3a-4da1-81a1-65fe88be39a8 "5b38bd64-8e3a-4da1-81a1-65fe88be39a8" <http://data.lblod.info/id/personen/43046dc8-d37b-4c94-ada3-0db98106f7c9> "55554871445" )
+  ( ids:b9d6a6d5-723c-406f-9519-ccb9799928f3 "b9d6a6d5-723c-406f-9519-ccb9799928f3" <http://data.lblod.info/id/personen/7d28318b3d9da93eff68860519fbdc3d5d3b1c36053c07d6fe4d2be4db32d9ff> "56122043024" )
+  ( ids:c341494e-0eb0-4389-b4bf-5a881612045c "c341494e-0eb0-4389-b4bf-5a881612045c" <http://data.lblod.info/id/personen/dd36103f-2802-4d5c-bbe0-a1d2c1905a57> "79970606348" )
+  ( ids:02bff939-a7f2-484f-b527-63b32eab2c7e "02bff939-a7f2-484f-b527-63b32eab2c7e" <http://data.lblod.info/id/personen/f2a49678-cd69-4cef-89d2-9a007e70b707> "71434104328" )
+  ( ids:1c36929c-41f1-47ec-bbf6-4f57c6a4a65a "1c36929c-41f1-47ec-bbf6-4f57c6a4a65a" <http://data.lblod.info/id/personen/bdeec145-8429-48b7-8a37-2462dc5c2c74> "23626673642" )
+  ( ids:5fea815b-3ef8-45bc-8094-e1f50767cb67 "5fea815b-3ef8-45bc-8094-e1f50767cb67" <http://data.lblod.info/id/personen/28ae200da38f6189d018fda61ec1c4b07a463777902aa435cc13b6305146ad5d> "17004337430" )
+  ( ids:11796e2a-580c-4e21-b32c-ae57329e9c26 "11796e2a-580c-4e21-b32c-ae57329e9c26" <http://data.lblod.info/id/personen/33f08801bf2dff6fbec0258448cad74b99280649b007910a8cc2e6c2d7274282> "55012976137" )
+  ( ids:ac18beaf-6a64-4d8d-8787-d4ebb12fb0e9 "ac18beaf-6a64-4d8d-8787-d4ebb12fb0e9" <http://data.lblod.info/id/personen/43604d44146e57dd2c033ff95df62145745cb543b438df29aec0630735ba0b84> "40995774248" )
+  ( ids:2600d3d9-e835-4414-8da0-ba7807dae2c5 "2600d3d9-e835-4414-8da0-ba7807dae2c5" <http://data.lblod.info/id/personen/8498f8c7f8a909f66e0693f766079a51f37a30fe88eb61aefcc883e8d84836ec> "28195618041" )
+  ( ids:1f80b71e-1add-4b35-ada7-6dc8983c6d9d "1f80b71e-1add-4b35-ada7-6dc8983c6d9d" <http://data.lblod.info/id/personen/f6065d55d6a5b03d27f722418c693b1dadb19258c08940d87599bdb91f2f601f> "91899506957" )
+  ( ids:a29befb0-86cb-466e-b697-633802f68274 "a29befb0-86cb-466e-b697-633802f68274" <http://data.lblod.info/id/personen/ab126555-43b6-4272-a3b1-2a330eaefd03> "45305857947" )
+  ( ids:c0a233b2-17a6-4eb6-9cee-826fbbeacc5c "c0a233b2-17a6-4eb6-9cee-826fbbeacc5c" <http://data.lblod.info/id/personen/9d004aaf316b774fa4c33acba916cc9a5c4ff15130c113901f42439ff44c4c98> "22801550226" )
+  ( ids:d5fbadb0-3971-4b58-992c-936278c6e37f "d5fbadb0-3971-4b58-992c-936278c6e37f" <http://data.lblod.info/id/personen/24bc66bb312550023c0265cbc3a5875c7b8da17b40164ea489b501fbcc5980d3> "48917237244" )
+  ( ids:790b7b26-b832-4863-a1e5-67125d0cfd1d "790b7b26-b832-4863-a1e5-67125d0cfd1d" <http://data.lblod.info/id/personen/d8c84720f68ea9b00912a98f128f4b3d51c9bbbe3f202aedf347b4324d6a91a2> "77701445541" )
+  ( ids:6243e890-a45b-4331-bb39-21413a24f1d4 "6243e890-a45b-4331-bb39-21413a24f1d4" <http://data.lblod.info/id/personen/cc7477719cb1ebb5f054c4d6a1d7193bb4814ad483ca20b5953ef4272c826632> "52636195745" )
+  ( ids:3266e9dd-dcc4-45c8-b924-027759db8374 "3266e9dd-dcc4-45c8-b924-027759db8374" <http://data.lblod.info/id/personen/f43e08061b50cdd45dc5d3468b14ebb0683a343dcea62b44462714bf83c7fd91> "11919279444" )
+  ( ids:d19bf3e5-653e-48a4-b66c-e68c09dee47e "d19bf3e5-653e-48a4-b66c-e68c09dee47e" <http://data.lblod.info/id/personen/1276f597b6527e09ee4f480f6dc210b5cb92e0135524a9b503725d41328a2463> "92318632944" )
+  ( ids:f674c265-3319-4122-a196-851ed6363768 "f674c265-3319-4122-a196-851ed6363768" <http://data.lblod.info/id/personen/d96fe5944336eea8bcfa97a9dd3ab5c264d1738e534655f0fba411055260fb13> "16930544033" )
+  ( ids:c324ea2b-64d0-432d-9305-11db03b65e0e "c324ea2b-64d0-432d-9305-11db03b65e0e" <http://data.lblod.info/id/personen/19fc28116b62f1db4eceb0b1af853f713b8b6aa247cee58f61c82bea9804625c> "25274078541" )
+  ( ids:3c72d9cc-a8a0-4b0f-9f2e-33655e1995c1 "3c72d9cc-a8a0-4b0f-9f2e-33655e1995c1" <http://data.lblod.info/id/personen/fff03e94-59b9-47e5-b22f-fdd5ff5a2914> "53910959345" )
+  ( ids:7dacf2a2-e04f-479a-8a27-3cfc1b614a0f "7dacf2a2-e04f-479a-8a27-3cfc1b614a0f" <http://data.lblod.info/id/personen/16419d6c1ebe6fefa98415ec43df2916b77e0e35bfc868a35594f19c6bc1b75b> "86793325751" )
+  ( ids:3b2e05c2-39ea-4cc2-9a52-277d35221162 "3b2e05c2-39ea-4cc2-9a52-277d35221162" <http://data.lblod.info/id/personen/d207243059ee715a9ecd00c3a9945d1a20136e93eb97f8f85650a95ac74ca04a> "86574186753" )
+  ( ids:a0e4eaa6-45f2-4b02-a5b7-7a7dba229f80 "a0e4eaa6-45f2-4b02-a5b7-7a7dba229f80" <http://data.lblod.info/id/personen/5BACCFEA98360D00090001C1> "11088884847" )
+  ( ids:5812a229-d96e-43b6-affa-871d70294964 "5812a229-d96e-43b6-affa-871d70294964" <http://data.lblod.info/id/personen/5C62802CD5BECA000800001B> "17474062840" )
+  ( ids:7f6bc62e-141c-4243-b2ce-fafe927abd51 "7f6bc62e-141c-4243-b2ce-fafe927abd51" <http://data.lblod.info/id/personen/d0e8c884-0f73-4e78-87ed-e59ccc932272> "65981102134" )
+  ( ids:d0ce0209-b208-49d5-bf4c-6f9f13f5a2c8 "d0ce0209-b208-49d5-bf4c-6f9f13f5a2c8" <http://data.lblod.info/id/personen/d817ec647efd8dae51f12f5988fc9e8eb93a1f99a211ed5a448478c460af2661> "46294745749" )
+  ( ids:a7100e59-7f3f-4051-9304-e9575cd70f9c "a7100e59-7f3f-4051-9304-e9575cd70f9c" <http://data.lblod.info/id/personen/6297404964a3dbded7acea9b1d381ccac3f5c1021a79418accdcf38734b29d31> "15978618248" )
+  ( ids:eb4287b8-cf44-40f4-b2db-3c53118be5cd "eb4287b8-cf44-40f4-b2db-3c53118be5cd" <http://data.lblod.info/id/personen/a9cd4a1c4df5ad5b87538133bfc90f2aae3081ce9825d8dfdc0beadbc8f5f28f> "48834489150" )
+  ( ids:7971d9a3-43fe-4376-b234-ce979fac2284 "7971d9a3-43fe-4376-b234-ce979fac2284" <http://data.lblod.info/id/personen/5cd738da9697c3c098e4558eca943e28e4fd8d2687522055710052341027c3ac> "12622652330" )
+  ( ids:c22ff10b-2b2e-4872-a6ff-108a3b7b1570 "c22ff10b-2b2e-4872-a6ff-108a3b7b1570" <http://data.lblod.info/id/personen/d3f17b9b84e24f90460ae74d3c20f948878c57a18f14237777e55d44128d13cc> "27092598649" )
+  ( ids:49b9be5e-f3e1-4e63-b4de-1ef603838cd7 "49b9be5e-f3e1-4e63-b4de-1ef603838cd7" <http://data.lblod.info/id/personen/4455b847e5d907614dfd381bbde66aadf9256f68f7676608c87d5025c3be6404> "28977464250" )
+  ( ids:02c9d831-3673-42e2-bee8-50e609208d2e "02c9d831-3673-42e2-bee8-50e609208d2e" <http://data.lblod.info/id/personen/8d3b7525a3358ecd3c4709fdb2a7300d1721ceffe8a7fac9f93ec1b44a76a213> "79055849048" )
+  ( ids:2492a931-3ce0-4f41-a41b-9577cf56c09e "2492a931-3ce0-4f41-a41b-9577cf56c09e" <http://data.lblod.info/id/personen/2d0073df52ea6bab2fb87a489ca6a1a29649366a850690dad1afc6ed4efade3b> "99263415242" )
+  ( ids:beb1f5e4-7c1c-4be8-b2d8-060711e067f7 "beb1f5e4-7c1c-4be8-b2d8-060711e067f7" <http://data.lblod.info/id/personen/a520f1cb1f7fe23af686b51c2e5cbcb3dea7f62e07371abe6890c1e532a042fd> "47724075239" )
+  ( ids:2963ec62-9847-4143-8d7e-7211db33696c "2963ec62-9847-4143-8d7e-7211db33696c" <http://data.lblod.info/id/personen/069886338c3863244dc6dbc2acfc4408cfbd5b2fd1a5296a80e14e9a4c29b68a> "61258680542" )
+  ( ids:c9297b7b-f0fe-48ec-88a0-a8b98e68f5fd "c9297b7b-f0fe-48ec-88a0-a8b98e68f5fd" <http://data.lblod.info/id/personen/c82045c0b1a8e440823eb42e170846b0dbc9abaee5c898a9471dbc0d3626bb5e> "22603160829" )
+  ( ids:9f1e18b3-d932-4e8b-b537-a13b765954fa "9f1e18b3-d932-4e8b-b537-a13b765954fa" <http://data.lblod.info/id/personen/d8e771a95d622119bd53857162b5f3e8754c59dadf6e3907f93b6a809c66b3f4> "35426530837" )
+  ( ids:85d1176c-47fc-4d2e-acbb-ba50e7cf8e40 "85d1176c-47fc-4d2e-acbb-ba50e7cf8e40" <http://data.lblod.info/id/personen/609ee92f453a31dc8849e8f3b142289973c6aabb996b380b76783d02cef03506> "93504063839" )
+  ( ids:96d08180-5a6e-4be1-a797-3ab41f6e91ad "96d08180-5a6e-4be1-a797-3ab41f6e91ad" <http://data.lblod.info/id/personen/74442d36-9682-4ff3-96bf-0cbe29dbef4e> "96950539855" )
+  ( ids:dcacef89-b5a5-4424-b3da-0049c88f53ab "dcacef89-b5a5-4424-b3da-0049c88f53ab" <http://data.lblod.info/id/personen/4a7dc0842997beb65ddfdec677f3b26fef82e932b3f76ea6368b65022105050a> "91655495348" )
+  ( ids:06164631-8038-41ab-b398-bc4a153495d3 "06164631-8038-41ab-b398-bc4a153495d3" <http://data.lblod.info/id/personen/888d967345288e618fa7c207d8c0ed70aa3ad905a734b3167eb64d4cc2918e69> "72863157545" )
+  ( ids:3c9ce20e-0554-4829-ac09-14f6e7318d9e "3c9ce20e-0554-4829-ac09-14f6e7318d9e" <http://data.lblod.info/id/personen/732ee75f1238408560cbac8fe20a2a11077d1b3fddb3777feac4d35b340deb51> "34403518938" )
+  ( ids:704249da-fbda-486b-88bf-0d21ac4c87ff "704249da-fbda-486b-88bf-0d21ac4c87ff" <http://data.lblod.info/id/personen/fc8800e3837188390414c806880d9aa1da4ac37c049abf5eb61fdcf42198e511> "79609787155" )
+  ( ids:b3439d6d-e9aa-404c-8fd2-78563090e483 "b3439d6d-e9aa-404c-8fd2-78563090e483" <http://data.lblod.info/id/personen/9f499430ab47d01a1b5f19333284fa925be9956e2e9cd27aaed52955ed44d99d> "66275170641" )
+  ( ids:e470ff50-83cb-4103-aedc-19921ae0e9b0 "e470ff50-83cb-4103-aedc-19921ae0e9b0" <http://data.lblod.info/id/personen/347fc30a-406f-476b-9b1d-314682f1a514> "76020867542" )
+  ( ids:2f11228c-9e06-4008-ba6c-3109f50fbc4b "2f11228c-9e06-4008-ba6c-3109f50fbc4b" <http://data.lblod.info/id/personen/8c381102-bed6-4bc8-b8f6-e01a9e6cd358> "30831557235" )
+  ( ids:231dd2e3-d0cf-4a31-9d49-804719fc1e16 "231dd2e3-d0cf-4a31-9d49-804719fc1e16" <http://data.lblod.info/id/personen/97bf8d8848fdb7ed12faeb902136f025022d26ac6928a00cd4235a9d2eb688c8> "91323655540" )
+  ( ids:5a69e5de-e5c0-4d31-b32a-2e6031cd777f "5a69e5de-e5c0-4d31-b32a-2e6031cd777f" <http://data.lblod.info/id/personen/c418d1a1-650c-473f-b37b-37c96f07fec9> "82721739444" )
+  ( ids:fb2056ba-d79e-4088-9cbf-0bb8f5a63e7a "fb2056ba-d79e-4088-9cbf-0bb8f5a63e7a" <http://data.lblod.info/id/personen/7029ea44dba9618a05e6332dd7c2f977a1bb9175b44ae1881d9c4b35be5c4cd9> "27328910841" )
+  ( ids:933d0880-8e22-4544-a2ab-97d74f9ef959 "933d0880-8e22-4544-a2ab-97d74f9ef959" <http://data.lblod.info/id/personen/463bedf5b8dc27614c3f5d4f16ee003a64088c1f5675319611a2771b71a05b0b> "13704228230" )
+  ( ids:271c2a69-0aa2-49ef-9817-e6e8edbccf95 "271c2a69-0aa2-49ef-9817-e6e8edbccf95" <http://data.lblod.info/id/personen/d6fc669c-35a7-40c9-a8cf-acca97a1a83a> "18934199550" )
+  ( ids:3f7229f0-968b-40c8-99af-a1d971da9b84 "3f7229f0-968b-40c8-99af-a1d971da9b84" <http://data.lblod.info/id/personen/6f7447cb0d7977eeafaee9804d9d801f4cd188b3ff5b380c142848d1781dc98f> "19943427949" )
+  ( ids:7b0d5951-6034-4c53-9709-16fa7be74f1b "7b0d5951-6034-4c53-9709-16fa7be74f1b" <http://data.lblod.info/id/personen/4d51ff2e70e56e98a4231fd8d00f07bc6d7e632f4cea07e3e7e2baff0250f9be> "83751944648" )
+  ( ids:edf7d171-dcbc-459d-81fe-2b69cebb7361 "edf7d171-dcbc-459d-81fe-2b69cebb7361" <http://data.lblod.info/id/personen/529789a9-686a-41b6-ab3e-10ddb161e6e9> "24242366636" )
+  ( ids:b6cd5547-9ea5-4b0a-b60c-11efa8de0b7c "b6cd5547-9ea5-4b0a-b60c-11efa8de0b7c" <http://data.lblod.info/id/personen/72e33d3f00c9e0e49202bcc3b9515de5704e09225d0939138062fe6114003561> "40025323525" )
+  ( ids:fdccfc44-00d6-4bc7-9c9a-5ed4b1690b8e "fdccfc44-00d6-4bc7-9c9a-5ed4b1690b8e" <http://data.lblod.info/id/personen/8693a5b15858e221daa95ffab0fc2d0d45d270545e2fc61f3ee5b96528e9534a> "55165790039" )
+  ( ids:9cc771fb-1b3e-4fb3-80bf-4722ed0d8781 "9cc771fb-1b3e-4fb3-80bf-4722ed0d8781" <http://data.lblod.info/id/personen/6b987f77141b52e5f976d8b77bf976d55aa7faf49306e3e923c22b2154e8b270> "75792288655" )
+  ( ids:69f4c631-c2b5-4b0f-95a5-45bb93b193fc "69f4c631-c2b5-4b0f-95a5-45bb93b193fc" <http://data.lblod.info/id/personen/dfeb96f4bccb427af26902e694ec98ffb34e2eed165e6097186808720713ac74> "52799247349" )
+  ( ids:d9a96f7b-eec2-4dc9-9757-5cb0f1ebcd97 "d9a96f7b-eec2-4dc9-9757-5cb0f1ebcd97" <http://data.lblod.info/id/personen/8c157396-5ef9-479f-a83c-2fc234793c03> "44383223333" )
+  ( ids:b53ddfd1-7677-4f4f-930b-1d6e0ea8d32a "b53ddfd1-7677-4f4f-930b-1d6e0ea8d32a" <http://data.lblod.info/id/personen/8d8da5c58832c5e733a97d4ddd6c6dc52c2e087a377a9a82583dc25e10208d13> "26964498049" )
+  ( ids:93bf9ee5-1eed-4a23-b798-0a917cc6dad9 "93bf9ee5-1eed-4a23-b798-0a917cc6dad9" <http://data.lblod.info/id/personen/8506a8e7f15f47161c822e3426901a6636ce639157a9e14f992d9a0ae7eddde3> "24317999853" )
+  ( ids:f6e16553-6a8f-4ca1-9a81-d6969a5c0902 "f6e16553-6a8f-4ca1-9a81-d6969a5c0902" <http://data.lblod.info/id/personen/c047f335c60e7e4e8d4c3114cba37a9fc3b159472d4237da92127211d8d34c2a> "59339410641" )
+  ( ids:9f3cf3b6-012d-40a3-a23d-77c45a347f08 "9f3cf3b6-012d-40a3-a23d-77c45a347f08" <http://data.lblod.info/id/personen/142c92a9a9200638829e4a56fd6562f60b64d6d83bc3c1eedfd425af2a622523> "52006845839" )
+  ( ids:fd4638e9-47db-4dc1-9038-bcbe9e9f8e72 "fd4638e9-47db-4dc1-9038-bcbe9e9f8e72" <http://data.lblod.info/id/personen/22b10df6a87fa62c8add12c67f5357ce7922ea2b5a4de9fbdff9faea9e6503e1> "89193651548" )
+  ( ids:1168186f-2979-4d5c-a94e-a14d71a96d9f "1168186f-2979-4d5c-a94e-a14d71a96d9f" <http://data.lblod.info/id/personen/0926be25147501c779c82238d66190fb30f715e7fc7ff74693561e29fb386301> "74643863547" )
+  ( ids:b8125d96-9278-4a5a-b2f4-4cbb81b0d6a7 "b8125d96-9278-4a5a-b2f4-4cbb81b0d6a7" <http://data.lblod.info/id/personen/622500d7-d9ea-4fbd-be4a-a2275e649179> "41455930840" )
+  ( ids:c5b5a25e-d66f-410a-b950-29aeafd25139 "c5b5a25e-d66f-410a-b950-29aeafd25139" <http://data.lblod.info/id/personen/fa71736e6f7bfc1bb26332cdde145ebdfd6ca473dbf6578b0a2e1af83f259c1a> "42755601031" )
+  ( ids:8da85742-ffc6-48c5-88bd-89d6dae4a508 "8da85742-ffc6-48c5-88bd-89d6dae4a508" <http://data.lblod.info/id/personen/2f77d290bcd6b5835b0c83fe137b4ff114c2a3e079b61105cf6ee80ce0e28b49> "49829236044" )
+  }
+}

--- a/queries/generate-election-results/query.sparql
+++ b/queries/generate-election-results/query.sparql
@@ -1,0 +1,34 @@
+# Query used to generate the csv content for a kieslijst based on (fake) content in our db
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX regorg: <https://www.w3.org/ns/regorg#>
+
+
+SELECT ?lastName ?firstName ?kieskring ?geslacht MIN(?fractieNaam) as ?lijst WHERE {
+SELECT ?lastName ?firstName STRAFTER(?gemeenteNaam, " ") as ?kieskring SUBSTR(?gender, 1,1) as ?geslacht ?fractieNaam WHERE {
+	?person ^mandaat:isBestuurlijkeAliasVan ?mandataris.
+	?person persoon:geslacht ?genderCode.
+	?genderCode skos:prefLabel ?gender.
+	?mandataris a mandaat:Mandataris .
+	?mandataris org:holds / ^org:hasPost / mandaat:isTijdspecialisatieVan ?orgaan .
+		?mandataris org:hasMembership ?lidmaatschap.
+		?lidmaatschap org:organisation ?fractie.
+		?fractie regorg:legalName ?fractieNaam.
+
+	?orgaan skos:prefLabel ?gemeenteNaam.
+	?orgaan besluit:classificatie / skos:prefLabel "Gemeenteraad" .
+	?orgaan besluit:bestuurt ?bestuurseenheid .
+
+	?person foaf:familyName ?lastName.
+	?person persoon:gebruikteVoornaam ?firstName.
+
+	VALUES ?bestuurseenheid {
+		<http://data.lblod.info/id/bestuurseenheden/d769b4b9411ad25f67c1d60b0a403178e24a800e1671fb3258280495011d8e18>
+		<http://data.lblod.info/id/bestuurseenheden/5116efa8-e96e-46a2-aba6-c077e9056a96>
+		<http://data.lblod.info/id/bestuurseenheden/ba4d960fe3e01984e15fd0b141028bab8f2b9b240bf1e5ab639ba0d7fe4dc522>
+	}
+}
+} GROUP BY ?lastName ?firstName ?kieskring ?geslacht ORDER BY ?kieskring


### PR DESCRIPTION
example of mandataris that now has (fake) rrn
![image](https://github.com/lblod/app-lokaal-mandatenbeheer/assets/1076194/38e6488b-f9d7-4626-af17-3a47937a0766)
