### PR TITLE
remove abstract-resources from domain.lisp

### DIFF
--- a/config/resources/domain.lisp
+++ b/config/resources/domain.lisp
@@ -11,8 +11,6 @@
 (defparameter sparql:*experimental-no-application-graph-for-sudo-select-queries* t)
 (setf *fetch-all-types-in-construct-queries* t)
 
-(read-domain-file "abstract-resources.lisp")
-
 (read-domain-file "concept-scheme.lisp")
 (read-domain-file "files.lisp")
 (read-domain-file "user.lisp")


### PR DESCRIPTION
Resources was crashing because domain.lisp still imported abstract-resources.lisp which was removed.