### PR TITLE
Add sh:order to mandataris publication status concept scheme

### DIFF
--- a/config/migrations/2024/20240412000000-mandataris-publication-status.sparql
+++ b/config/migrations/2024/20240412000000-mandataris-publication-status.sparql
@@ -4,8 +4,6 @@ PREFIX rdfs:	<http://www.w3.org/2000/01/rdf-schema#>
 PREFIX mu:   <http://mu.semte.ch/vocabularies/core/>
 PREFIX extlmb:  <http://mu.semte.ch/vocabularies/ext/lmb/>
 PREFIX mps: <http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/>
-PREFIX sh: <http://www.w3.org/ns/shacl#>
-PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>
 
 INSERT DATA {
   GRAPH <http://mu.semte.ch/graphs/public> {
@@ -23,8 +21,7 @@ INSERT DATA {
         skos:Concept,
         extlmb:MandatarisPublicationStatusCode;
       skos:prefLabel "Draft";
-      mu:uuid "588ce330-4abb-4448-9776-a17d9305df07";
-      sh:order "1"^^xsd:integer.
+      mu:uuid "588ce330-4abb-4448-9776-a17d9305df07".
 
     mps:d3b12468-3720-4cb0-95b4-6aa2996ab188
       skos:topConceptOf extlmb:mandataris-publication-status-code;
@@ -33,8 +30,7 @@ INSERT DATA {
         skos:Concept,
         extlmb:MandatarisPublicationStatusCode;
       skos:prefLabel "Effectief";
-      mu:uuid "d3b12468-3720-4cb0-95b4-6aa2996ab188";
-      sh:order "2"^^xsd:integer.
+      mu:uuid "d3b12468-3720-4cb0-95b4-6aa2996ab188".
 
     mps:9d8fd14d-95d0-4f5e-b3a5-a56a126227b6
       skos:topConceptOf extlmb:mandataris-publication-status-code;
@@ -43,7 +39,6 @@ INSERT DATA {
         skos:Concept,
         extlmb:MandatarisPublicationStatusCode;
       skos:prefLabel "Bekrachtigd";
-      mu:uuid "9d8fd14d-95d0-4f5e-b3a5-a56a126227b6";
-      sh:order "3"^^xsd:integer.
+      mu:uuid "9d8fd14d-95d0-4f5e-b3a5-a56a126227b6".
   }
 }

--- a/config/migrations/2024/20240412000000-mandataris-publication-status.sparql
+++ b/config/migrations/2024/20240412000000-mandataris-publication-status.sparql
@@ -4,6 +4,8 @@ PREFIX rdfs:	<http://www.w3.org/2000/01/rdf-schema#>
 PREFIX mu:   <http://mu.semte.ch/vocabularies/core/>
 PREFIX extlmb:  <http://mu.semte.ch/vocabularies/ext/lmb/>
 PREFIX mps: <http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>
 
 INSERT DATA {
   GRAPH <http://mu.semte.ch/graphs/public> {
@@ -21,7 +23,8 @@ INSERT DATA {
         skos:Concept,
         extlmb:MandatarisPublicationStatusCode;
       skos:prefLabel "Draft";
-      mu:uuid "588ce330-4abb-4448-9776-a17d9305df07".
+      mu:uuid "588ce330-4abb-4448-9776-a17d9305df07";
+      sh:order "1"^^xsd:integer.
 
     mps:d3b12468-3720-4cb0-95b4-6aa2996ab188
       skos:topConceptOf extlmb:mandataris-publication-status-code;
@@ -30,7 +33,8 @@ INSERT DATA {
         skos:Concept,
         extlmb:MandatarisPublicationStatusCode;
       skos:prefLabel "Effectief";
-      mu:uuid "d3b12468-3720-4cb0-95b4-6aa2996ab188".
+      mu:uuid "d3b12468-3720-4cb0-95b4-6aa2996ab188";
+      sh:order "2"^^xsd:integer.
 
     mps:9d8fd14d-95d0-4f5e-b3a5-a56a126227b6
       skos:topConceptOf extlmb:mandataris-publication-status-code;
@@ -39,6 +43,7 @@ INSERT DATA {
         skos:Concept,
         extlmb:MandatarisPublicationStatusCode;
       skos:prefLabel "Bekrachtigd";
-      mu:uuid "9d8fd14d-95d0-4f5e-b3a5-a56a126227b6".
+      mu:uuid "9d8fd14d-95d0-4f5e-b3a5-a56a126227b6";
+      sh:order "3"^^xsd:integer.
   }
 }

--- a/config/migrations/2024/20240424000000-mandataris-publication-status-order.sparql
+++ b/config/migrations/2024/20240424000000-mandataris-publication-status-order.sparql
@@ -1,0 +1,17 @@
+PREFIX mps: <http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+
+    mps:588ce330-4abb-4448-9776-a17d9305df07 
+      sh:order "1"^^xsd:integer.
+
+    mps:d3b12468-3720-4cb0-95b4-6aa2996ab188
+      sh:order "2"^^xsd:integer.
+
+    mps:9d8fd14d-95d0-4f5e-b3a5-a56a126227b6
+      sh:order "3"^^xsd:integer.
+  }
+}

--- a/config/resources/external-mandaat.lisp
+++ b/config/resources/external-mandaat.lisp
@@ -112,7 +112,8 @@
 
 (define-resource mandataris-publication-status-code ()
   :class (s-prefix "extlmb:MandatarisPublicationStatusCode")
-  :properties `((:label :string ,(s-prefix "skos:prefLabel")))
+  :properties `((:label :string ,(s-prefix "skos:prefLabel"))
+                (:order :number ,(s-prefix "sh:order")))
   :resource-base (s-url "http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/")
   :features '(include-uri)
   :on-path "mandataris-publication-status-codes")


### PR DESCRIPTION
## Description

We want to be able to show the mandataris publication statuses in a consistent order, regardless of the order in which they were inserted into the database. This can be achieved by adding an extra sh:order triple to the concepts in the publication status migration. These triples will then be used in the frontend for manual sorting.

## How to test
Explanation in frontend PR

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/184
