### PR TITLE
LMB-376: POC publish the LDES to loket 

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -76,9 +76,12 @@ services:
   ldes-backend:
     restart: "no"
     environment:
-      BASE_URL: "http://localhost/streams/ldes"
+      BASE_URL: "http://ldes-backend/"
     ports:
       - "6666:80"
+    networks:
+      - default
+      - debug
   vendor-login:
     restart: "no"
   sparql-authorization-wrapper:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,7 +181,7 @@ services:
     labels:
       - "logging=true"
     environment:
-      BASE_URL: "https://lmb.lblod.info/streams/ldes"
+      BASE_URL: "https://lmb.lblod.info/streams/ldes/"
       FOLDER_DEPTH: 1
       PAGE_RESOURCES_COUNT: 10
       LDES_STREAM_PREFIX: "http://lmb.lblod.info/streams/ldes/"


### PR DESCRIPTION
## Description

We want our ldes to be consumed by Loket app. 

## How to test

1. Checkout the branch `git checkout LMB-376-ldes-consumer-for-mandatenbeheer-poc`
2. Checkout loket on branch `git checkout LMB-376-ldes-consumer-for-mandatenbeheer-poc`
3. `docker compose up -d` LMB and loket

## Links to other PR's

- https://github.com/lblod/app-digitaal-loket/pull/565
