### PR TITLE
merge ldes streams into single stream, but publish 3 versions

### DIFF
--- a/config/ldes-delta-pusher/handle-mandataris-type.ts
+++ b/config/ldes-delta-pusher/handle-mandataris-type.ts
@@ -27,8 +27,12 @@ const keepMandatarisTypesQuery = async (
     .map((binding) => {
       const isNotDraft =
         binding.publicationStatus?.value !== MANDATARIS_DRAFT_STATE;
-      const ldesType = isNotDraft ? "mandataris" : "mandataris-draft"; // default to non-draft if not present
-      return { uri: binding.s.value, ldesType };
+      const ldesType = isNotDraft ? "public" : "abb"; // default to non-draft if not present
+      return {
+        uri: binding.s.value,
+        ldesType,
+        type: "http://data.vlaanderen.be/ns/mandaat#Mandataris",
+      };
     })
     .filter((b) => !!b) as InterestingSubject[];
 };

--- a/config/ldes-delta-pusher/handle-regular-types.ts
+++ b/config/ldes-delta-pusher/handle-regular-types.ts
@@ -6,13 +6,15 @@ import {
 } from "./handle-types-util";
 
 const regularTypesToLDESMapping = {
-  "http://data.vlaanderen.be/ns/mandaat#Fractie": "fractie",
-  "http://www.w3.org/ns/org#Membership": "lidmaatschap",
-  "http://data.vlaanderen.be/ns/mandaat#Mandaat": "mandaat",
-  "http://www.w3.org/ns/person#Person": "persoon",
-  "http://purl.org/dc/terms/PeriodOfTime": "periode",
-  "http://www.w3.org/ns/adms#Identifier": "identifier",
-  "http://data.vlaanderen.be/ns/persoon#Geboorte": "geboorte",
+  "http://data.vlaanderen.be/ns/mandaat#Fractie": "public",
+  "http://www.w3.org/ns/org#Membership": "public",
+  "http://data.vlaanderen.be/ns/mandaat#Mandaat": "public",
+  "http://www.w3.org/ns/person#Person": "public",
+  "http://purl.org/dc/terms/PeriodOfTime": "public",
+  "http://www.w3.org/ns/adms#Identifier": "abb",
+  "http://data.vlaanderen.be/ns/persoon#Geboorte": "public",
+  "http://schema.org/ContactPoint": "abb",
+  "http://www.w3.org/ns/locn#Address": "abb",
 };
 
 const keepRegularTypesQuery = async (
@@ -34,7 +36,7 @@ const keepRegularTypesQuery = async (
       if (!ldesType) {
         return null;
       }
-      return { uri: binding.s.value, ldesType };
+      return { uri: binding.s.value, ldesType, type: binding.type.value };
     })
     .filter((b) => !!b);
 };

--- a/config/ldes-delta-pusher/handle-types-util.ts
+++ b/config/ldes-delta-pusher/handle-types-util.ts
@@ -1,12 +1,7 @@
 import { Changeset } from "../types";
 import { query } from "mu";
-import { publish } from "./publisher";
+import { InterestingSubject, LDES_TYPE, publish } from "./publisher";
 import { log } from "./logger";
-
-export type InterestingSubject = {
-  uri: string;
-  ldesType: string;
-};
 
 type SubjectFilter = (subjects: string[]) => Promise<InterestingSubject[]>;
 
@@ -58,6 +53,6 @@ export const publishInterestingSubjects = async (
   // do this serially to avoid overloading the stream endpoint
   let current: InterestingSubject | undefined;
   while ((current = interestingSubjects.pop())) {
-    await publish(current.ldesType, current.uri);
+    await publish(current);
   }
 };

--- a/config/ldes-delta-pusher/publisher.ts
+++ b/config/ldes-delta-pusher/publisher.ts
@@ -2,15 +2,34 @@ import { query, sparqlEscapeUri, sparqlEscape } from "mu";
 import { LDES_ENDPOINT } from "../config";
 import fetch from "node-fetch";
 import { log } from "./logger";
+export type LDES_TYPE = "public" | "abb" | "internal";
+export type InterestingSubject = {
+  uri: string;
+  type: string;
+  ldesType: LDES_TYPE;
+};
 
-const fetchSubjectData = async (subject: string) => {
+const fetchSubjectData = async (
+  subject: InterestingSubject,
+  target: string
+) => {
+  let predicateLimiter = "";
+  if (["abb", "public"].includes(target) && modelProperties[subject.type]) {
+    let properties = modelProperties[subject.type];
+    properties = properties.concat(defaultProperties);
+    predicateLimiter = `
+    VALUES ?p {
+      ${properties.map((p) => sparqlEscapeUri(p)).join("\n")}
+    }`;
+  }
   const data = await query(`
     CONSTRUCT {
-      <${subject}> ?p ?o .
+      <${subject.uri}> ?p ?o .
     } WHERE {
       GRAPH ?g {
-        <${subject}> ?p ?o .
+        <${subject.uri}> ?p ?o .
       }
+      ${predicateLimiter}
       FILTER NOT EXISTS {
         ?g a <http://mu.semte.ch/vocabularies/ext/FormHistory> .
       }
@@ -40,6 +59,93 @@ const datatypeNames = {
   "http://www.w3.org/2001/XMLSchema#boolean": "bool",
 };
 
+const defaultProperties = [
+  "http://purl.org/dc/terms/modified",
+  "http://www.w3.org/2002/07/owl#sameAs",
+  "http://mu.semte.ch/vocabularies/core/uuid",
+  "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+];
+// which properties to share for all our known types on the public and abb stream
+const modelProperties = {
+  "http://data.vlaanderen.be/ns/mandaat#Fractie": [
+    "https://www.w3.org/ns/regorg#legalName",
+    "http://www.w3.org/ns/org#memberOf",
+    "http://www.w3.org/ns/org#linkedTo",
+    "http://mu.semte.ch/vocabularies/ext/isFractietype",
+  ],
+  "http://www.w3.org/ns/org#Membership": [
+    "http://www.w3.org/ns/org#organisation",
+    "http://www.w3.org/ns/org#hasMembership",
+    "http://www.w3.org/ns/org#memberDuring",
+  ],
+  "http://data.vlaanderen.be/ns/mandaat#Mandaat": [
+    "http://data.vlaanderen.be/ns/mandaat#aantalHouders",
+  ],
+  "http://www.w3.org/ns/person#Person": [
+    "http://xmlns.com/foaf/0.1/familyName",
+    "http://xmlns.com/foaf/0.1/name",
+    "http://data.vlaanderen.be/ns/persoon#gebruikteVoornaam",
+    "http://data.vlaanderen.be/ns/persoon#heeftNationaliteit",
+    "http://data.vlaanderen.be/ns/persoon#heeftGeboorte",
+    "http://www.w3.org/ns/adms#identifier",
+    "http://data.vlaanderen.be/ns/persoon#geslacht",
+  ],
+  "http://purl.org/dc/terms/PeriodOfTime": [
+    "http://data.vlaanderen.be/ns/generiek#begin",
+    "http://data.vlaanderen.be/ns/generiek#einde",
+  ],
+  "http://www.w3.org/ns/adms#Identifier": [
+    "http://www.w3.org/2004/02/skos/core#notation",
+  ],
+  "http://data.vlaanderen.be/ns/persoon#Geboorte": [
+    "http://data.vlaanderen.be/ns/persoon#datum",
+  ],
+  "http://data.vlaanderen.be/ns/mandaat#Mandataris": [
+    "http://data.vlaanderen.be/ns/mandaat#rangorde",
+    "http://data.vlaanderen.be/ns/mandaat#start",
+    "http://data.vlaanderen.be/ns/mandaat#einde",
+    "http://mu.semte.ch/vocabularies/ext/datumEedaflegging",
+    "http://mu.semte.ch/vocabularies/ext/datumMinistrieelBesluit",
+    "http://mu.semte.ch/vocabularies/ext/generatedFrom",
+    "http://www.w3.org/2004/02/skos/core#changeNote",
+    "http://data.vlaanderen.be/ns/mandaat#isTijdelijkVervangenDoor",
+    "http://schema.org/contactPoint",
+    "http://data.vlaanderen.be/ns/mandaat#beleidsdomein",
+    "http://www.w3.org/ns/org#holds",
+    "http://www.w3.org/ns/org#hasMembership",
+    "http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan",
+    "http://data.vlaanderen.be/ns/mandaat#status",
+    "http://mu.semte.ch/vocabularies/ext/lmb/hasPublicationStatus",
+  ],
+  "http://schema.org/ContactPoint": [
+    "http://schema.org/email",
+    "http://schema.org/faxNumber",
+    "http://xmlns.com/foaf/0.1/name",
+    "http://xmlns.com/foaf/0.1/firstName",
+    "http://xmlns.com/foaf/0.1/familyName",
+    "http://xmlns.com/foaf/0.1/page",
+    "http://schema.org/telephone",
+    "http://schema.org/contactType",
+    "http://www.w3.org/ns/locn#address",
+    "http://mu.semte.ch/vocabularies/ext/secondaryContactPoint",
+  ],
+  "http://www.w3.org/ns/locn#Address": [
+    "https://data.vlaanderen.be/ns/adres#Adresvoorstelling.busnummer",
+    "https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer",
+    "http://www.w3.org/ns/locn#thoroughfare",
+    "http://www.w3.org/ns/locn#postCode",
+    "https://data.vlaanderen.be/ns/adres#gemeentenaam",
+    "https://data.vlaanderen.be/ns/adres#land",
+    "http://www.w3.org/ns/locn#locatorDesignator",
+    "http://www.w3.org/ns/locn#locatorName",
+    "http://www.w3.org/ns/locn#poBox",
+    "http://www.w3.org/ns/locn#postName",
+    "http://www.w3.org/ns/locn#fullAddress",
+    "http://data.lblod.info/vocabularies/leidinggevenden/adresRegisterId",
+    "https://data.vlaanderen.be/ns/adres#verwijstNaar",
+  ],
+};
+
 const sparqlEscapeObject = (bindingObject): string => {
   const escapeType = datatypeNames[bindingObject.datatype] || "string";
   return bindingObject.type === "uri"
@@ -52,18 +158,32 @@ const bindingToTriple = (binding) =>
     binding.p.value
   )} ${sparqlEscapeObject(binding.o)} .`;
 
+const streamTargets: Record<LDES_TYPE, string[]> = {
+  public: ["public", "abb", "internal"],
+  abb: ["abb", "internal"],
+  internal: ["internal"],
+};
+
 /**
  * Publish the currently known info for the given subject URI to the LDES endpoint of the given type
- * @param ldesType the name of the LDES endpoint to publish to (e.g. "person")
+ * @param ldesType the type of the LDES endpoint to publish to (e.g. "public" or "abb")
  * @param subject the uri of the subject to fetch data for and publish
  */
-export const publish = async (ldesType: string, subject: string) => {
-  const data = await fetchSubjectData(subject);
-  log(`Publishing data for subject ${subject}:\n${data}`, "debug");
-  await sendLDESRequest(ldesType, data).catch((e) => {
-    log(
-      `Error publishing data for subject ${subject} to LDES endpoint ${ldesType}: ${e}`,
-      "error"
-    );
-  });
+export const publish = async (subject: InterestingSubject) => {
+  const targets = streamTargets[subject.ldesType] || [];
+  await Promise.all(
+    targets.map(async (target) => {
+      const data = await fetchSubjectData(subject, target);
+      log(
+        `[${target}] Publishing data for subject ${subject.uri}:\n${data}`,
+        "debug"
+      );
+      return sendLDESRequest(target, data).catch((e) => {
+        log(
+          `Error publishing data for subject ${subject.uri} to LDES endpoint ${subject.ldesType}: ${e}`,
+          "error"
+        );
+      });
+    })
+  );
 };

--- a/config/resources/external-contact.lisp
+++ b/config/resources/external-contact.lisp
@@ -4,8 +4,7 @@
 
 (define-resource contact-punt ()
   :class (s-prefix "schema:ContactPoint")
-  :properties `((:aanschrijfprefix :language-string-set ,(s-prefix "vcard:honorific-prefix"))
-                (:email :string ,(s-prefix "schema:email"))
+  :properties `((:email :string ,(s-prefix "schema:email"))
                 (:fax :string ,(s-prefix "schema:faxNumber"))
                 (:naam :string ,(s-prefix "foaf:name"))
                 (:voornaam :string ,(s-prefix "foaf:firstName"))

--- a/docs/LDES.md
+++ b/docs/LDES.md
@@ -65,12 +65,20 @@ This presents the question of how this peripheral knowledge reaches these differ
 - an LDES as discussed earlier. We can use the caching headers here to clarify that the resource isn't expected to change for another month or so. We can also terminate an LDES when we know no more data is going to change, e.g. for election results.
 - we can make an interface (API, not LDES) where they just fetch the latest version.
 
+## Published streams
+
+This application will publish 3 streams:
+
+- **public**: a public stream with limited information. This stream contains the information sent to abb but removes sensitive information like RRN numbers of person entities
+- **abb**: a stream to be used by ABB consumers. This is to be secured in the future and holds all instances that are part of the Mandatendatabank model: mandaat:Mandataris, mandaat:Fractie, org:Membership, mandaat:Mandaat, person:Person, dct:PeriodOfTime, adms:Identifier, persoon:Geboorte, schema:ContactPoint, locn:Address. It only exposes the properties known to the model + dct:modified, mu:uuid and rdf:type.
+- **public**: a stream to be used internally. Currently this exposes the same model instances as the abb stream but with all of their properties.
+
 ## LDES setup
 
 The LDES spec can be found [here](https://semiceu.github.io/LinkedDataEventStreams/).
 We will be using the implementation provided by [redpencil.io on their github](https://github.com/redpencilio/fragmentation-producer-service) to publish the LDES. It will be fed using our own service that monitors deltas on our SEAS instance.
 
-We'll use a time-fragmenter, one stream will be set up per type of instance that we will share, with pagination and the following setup for versioning:
+We'll use a time-fragmenter with pagination and the following setup for versioning:
 
     @prefix dct: <http://purl.org/dc/terms/>.
     @prefix ext: <http://mu.semte.ch/vocabularies/ext/>.


### PR DESCRIPTION
## Description

Merges the ldes streams we produced up till now so one stream has all types that we want to publish (mandaten, mandatarissen, fracties,...). 
Then publish 3 different versions of those streams: 
- public: everything in abb stream except sensitive data (like rrn identifiers)
- abb: everything that matches the model
- internal: everything (currently only the model classes but this can be extended later)

none of these streams are secured yet.

## How to test

- checkout this pr, remove your ldes data folder's contents (keep the folder).
- create a person
- modify a fraction
- both items should be present in the ldes streams. The identifier should only be present in the internal and abb streams. If you want to check that only the data that matches the model is present, remove a predicate from a type (e.g. last name) and check that the value is present in the internal stream and not in the others

