### PR TITLE
Add Aangewezen Burgemeester Status Code

### DIFF
--- a/config/form-content/mandataris-edit/form.ttl
+++ b/config/form-content/mandataris-edit/form.ttl
@@ -19,7 +19,7 @@ ext:mandaatF
     sh:path org:holds.
 ext:mandatarisStatusCodeF
     a form:Field;
-    form:displayType displayTypes:conceptSchemeSelectorWithoutMeta;
+    form:displayType displayTypes:mandatarisStatusCodeSelector;
     sh:group ext:editMandatarisPG;
     sh:name "Status";
     form:help "Titelvoerdend is enkel voor burgemeester";

--- a/config/migrations/2024/20240426000000-aangewezen-burgemeester.sparql
+++ b/config/migrations/2024/20240426000000-aangewezen-burgemeester.sparql
@@ -1,0 +1,19 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX cs: <http://data.vlaanderen.be/id/conceptscheme/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX ext:	<http://mu.semte.ch/vocabularies/ext/>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX msc: <http://data.vlaanderen.be/id/concept/MandatarisStatusCode/>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    msc:e371f89a-9e83-4a8c-a98e-cd09226fa549
+	    skos:topConceptOf	cs:MandatarisStatusCode;
+	    skos:inScheme	cs:MandatarisStatusCode;
+      rdf:type
+        skos:Concept,
+        ext:MandatarisStatusCode;
+	    skos:prefLabel "Aangewezen";
+	    mu:uuid "e371f89a-9e83-4a8c-a98e-cd09226fa549".
+  }
+}


### PR DESCRIPTION
## Description

The list of mandataris statusses is extended with a new 'aangewezen' status. Selecting this status should only be possible when selecting the status of a Burgemeester mandataris.

The list 

## How to test

Explanation in frontend PR

## Links to other PR's

- TODO
