### PR TITLE
mandataris-new Form Also Has Custom Status Display Type

### DIFF
--- a/config/form-content/mandataris-new/form.ttl
+++ b/config/form-content/mandataris-new/form.ttl
@@ -27,7 +27,7 @@ ext:mandaatF
     sh:path org:holds.
 ext:mandatarisStatusCodeF
     a form:Field;
-    form:displayType displayTypes:conceptSchemeSelectorWithoutMeta;
+    form:displayType displayTypes:mandatarisStatusCodeSelector;
     sh:group ext:mandatarisPG;
     sh:name "Status";
     form:help "Titelvoerdend is enkel voor burgemeester";


### PR DESCRIPTION
## Description

The mandataris-new form should also filter the display types according to the mandataris being Burgemeester or not, in the same way that it is done in mandataris-edit.

## How to test

- Go to the create new mandatee form
- Select the Burgemeester mandaat
- "Aangewezen" should be available in the status selector
- Change the mandaat to something else
- "Aangewezen" should not be available in the status selector

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/193
