### PR TITLE
allow ldes to catch up after restarting

### DIFF
--- a/config/ldes-delta-pusher/catchUp.ts
+++ b/config/ldes-delta-pusher/catchUp.ts
@@ -13,14 +13,13 @@ export const handlePage = async (items: CatchupPageItem[]) => {
       mandatarisSubjects.push(item.uri);
     } else {
       const ldesType = getLdesForRegularType(item.type);
-      if (!ldesType) {
-        return;
+      if (ldesType) {
+        interestingSubjects.push({
+          uri: item.uri,
+          ldesType,
+          type: item.type,
+        });
       }
-      interestingSubjects.push({
-        uri: item.uri,
-        ldesType,
-        type: item.type,
-      });
     }
   });
 
@@ -28,12 +27,11 @@ export const handlePage = async (items: CatchupPageItem[]) => {
     mandatarisSubjects
   );
   mandatarisSubjectsWithDraftState.map((binding) => {
+    const isDraftMandataris =
+      binding.publicationStatus?.value === MANDATARIS_DRAFT_STATE;
     interestingSubjects.push({
       uri: binding.s.value,
-      ldesType:
-        binding.publicationStatus?.value !== MANDATARIS_DRAFT_STATE
-          ? "public"
-          : "abb",
+      ldesType: isDraftMandataris ? "abb" : "public",
       type: "http://data.vlaanderen.be/ns/mandaat#Mandataris",
     });
   });

--- a/config/ldes-delta-pusher/catchUp.ts
+++ b/config/ldes-delta-pusher/catchUp.ts
@@ -1,0 +1,45 @@
+import { CatchupPageItem } from "../types";
+import { toMandatarisDraftState } from "./handle-mandataris-type";
+import { getLdesForRegularType } from "./handle-regular-types";
+import { InterestingSubject, publish } from "./publisher";
+import { MANDATARIS_DRAFT_STATE } from "./utils/well-known-uris";
+
+export const handlePage = async (items: CatchupPageItem[]) => {
+  const interestingSubjects = [] as InterestingSubject[];
+  const mandatarisSubjects = [] as string[];
+  items.forEach((item) => {
+    // don't care about predicates and objects
+    if (item.type === "http://data.vlaanderen.be/ns/mandaat#Mandataris") {
+      mandatarisSubjects.push(item.uri);
+    } else {
+      const ldesType = getLdesForRegularType(item.type);
+      if (!ldesType) {
+        return;
+      }
+      interestingSubjects.push({
+        uri: item.uri,
+        ldesType,
+        type: item.type,
+      });
+    }
+  });
+
+  const mandatarisSubjectsWithDraftState = await toMandatarisDraftState(
+    mandatarisSubjects
+  );
+  mandatarisSubjectsWithDraftState.map((binding) => {
+    interestingSubjects.push({
+      uri: binding.s.value,
+      ldesType:
+        binding.publicationStatus?.value !== MANDATARIS_DRAFT_STATE
+          ? "public"
+          : "abb",
+      type: "http://data.vlaanderen.be/ns/mandaat#Mandataris",
+    });
+  });
+  // do this serially to avoid overloading the stream endpoint
+  let current: InterestingSubject | undefined;
+  while ((current = interestingSubjects.pop())) {
+    await publish(current);
+  }
+};

--- a/config/ldes-delta-pusher/dispatch.ts
+++ b/config/ldes-delta-pusher/dispatch.ts
@@ -10,14 +10,15 @@ export default async function dispatch(changesets: Changeset[]) {
 }
 
 function filterOutHistoryChanges(changesets: Changeset[]) {
-  const doesNotStartWithHistoryUri = (quad) => !quad.graph.value.startsWith('http://mu.semte.ch/graphs/formHistory');
+  const doesNotStartWithHistoryUri = (quad) =>
+    !quad.graph.value.startsWith("http://mu.semte.ch/graphs/formHistory");
 
-  return changesets.map(change => {
+  return changesets.map((change) => {
     const { inserts, deletes } = change;
 
     return {
       inserts: inserts.filter(doesNotStartWithHistoryUri),
       deletes: deletes.filter(doesNotStartWithHistoryUri),
-    }
-  })
+    };
+  });
 }

--- a/config/ldes-delta-pusher/handle-mandataris-type.ts
+++ b/config/ldes-delta-pusher/handle-mandataris-type.ts
@@ -6,9 +6,7 @@ import {
 } from "./handle-types-util";
 import { MANDATARIS_DRAFT_STATE } from "./utils/well-known-uris";
 
-const keepMandatarisTypesQuery = async (
-  subjects: string[]
-): Promise<InterestingSubject[]> => {
+export const toMandatarisDraftState = async (subjects: string[]) => {
   const matches = await query(`
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
       PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
@@ -23,7 +21,14 @@ const keepMandatarisTypesQuery = async (
         OPTIONAL { ?s extlmb:hasPublicationStatus ?publicationStatus. }
       }
     `);
-  return matches.results.bindings
+  return matches.results.bindings;
+};
+
+const keepMandatarisTypesQuery = async (
+  subjects: string[]
+): Promise<InterestingSubject[]> => {
+  const subjectsWithDraftState = await toMandatarisDraftState(subjects);
+  return subjectsWithDraftState
     .map((binding) => {
       const isNotDraft =
         binding.publicationStatus?.value !== MANDATARIS_DRAFT_STATE;

--- a/config/ldes-delta-pusher/handle-regular-types.ts
+++ b/config/ldes-delta-pusher/handle-regular-types.ts
@@ -17,6 +17,10 @@ const regularTypesToLDESMapping = {
   "http://www.w3.org/ns/locn#Address": "abb",
 };
 
+export const getLdesForRegularType = (type: string) => {
+  return regularTypesToLDESMapping[type];
+};
+
 const keepRegularTypesQuery = async (
   subjects: string[]
 ): Promise<InterestingSubject[]> => {
@@ -32,7 +36,7 @@ const keepRegularTypesQuery = async (
     `);
   return matches.results.bindings
     .map((binding) => {
-      const ldesType = regularTypesToLDESMapping[binding.type.value];
+      const ldesType = getLdesForRegularType(binding.type.value);
       if (!ldesType) {
         return null;
       }

--- a/config/migrations/2024/20240430082000-add-modified.sparql
+++ b/config/migrations/2024/20240430082000-add-modified.sparql
@@ -1,0 +1,41 @@
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX person: <http://www.w3.org/ns/person#>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX lblodlg: <http://data.lblod.info/vocabularies/leidinggevenden/>
+PREFIX schema: <http://schema.org/>
+PREFIX locn: <http://www.w3.org/ns/locn#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT {
+  GRAPH ?g {
+    ?s dct:modified ?defaultModified.
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?s a ?type
+    VALUES ?type {
+      mandaat:Mandataris
+      mandaat:Fractie
+      persoon:Geboorte
+      org:Membership
+      mandaat:Mandaat
+      ext:BeleidsdomeinCode
+      person:Person
+      dct:PeriodOfTime
+      adms:Idenfifier
+      besluit:Bestuursorgaan
+      lblodlg:Bestuursfunctie
+      lblodlg:Functionaris
+      ext:Installatievergadering
+      schema:ContactPoint
+      locn:Address
+    }
+  }
+  BIND("2024-01-01T00:00:00Z"^^xsd:dateTime AS ?defaultModified)
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,7 +164,7 @@ services:
   # LDES
   ##############################################################################
   ldes-delta-pusher:
-    image: redpencil/ldes-delta-pusher:0.1.1
+    image: redpencil/ldes-delta-pusher:0.2.0
     environment:
       LDES_ENDPOINT: "http://ldes-backend"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -183,7 +183,7 @@ services:
     environment:
       BASE_URL: "https://lmb.lblod.info/streams/ldes"
       FOLDER_DEPTH: 1
-      PAGE_RESOURCES_COUNT: 10
+      PAGE_RESOURCES_COUNT: 20
       LDES_STREAM_PREFIX: "http://lmb.lblod.info/streams/ldes/"
       TIME_TREE_RELATION_PATH: "http://www.w3.org/ns/prov#generatedAtTime"
       CACHE_SIZE: 10


### PR DESCRIPTION
## Description

This sets a dct:modified for all concepts we are interested in and configures the ldes-delta-pusher to push all changes to the ldes stream that it missed (done by comparing the dct:modified of concepts with the last one seen when the pusher was alive, if any).

## How to test

- remove your data/ldes-feed/* files/folders
- pull this pr and restart the migrations service so it runs the latest migration that is included
- your data now has a dct:modified for all concepts
- modify a random mandataris so you have a later modified date and the safety run the pusher does doesn't add all concepts twice (optional, but recommended)
- kill, rm and restart the ldes-delta-pusher
- see the ldes-stream files increase in count and when done, verify that the last change you made is indeed in the stream
