### PR TITLE
add mandataris service to app and dispatcher

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -310,6 +310,14 @@ defmodule Dispatcher do
   end
 
   #################################################################
+  # Mandataris api
+  #################################################################
+
+  match "/mandataris-api/*path", %{layer: :api_services, accept: %{any: true}} do
+    forward(conn, path, "http://mandataris/")
+  end
+
+  #################################################################
   # LDES
   #################################################################
   get "/streams/ldes/*path" do

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -67,6 +67,10 @@ services:
     restart: "no"
     profiles:
       - nodebug
+  mandataris:
+    restart: "no"
+    profiles:
+      - nodebug
   adressenregister:
     restart: "no"
   ldes-delta-pusher:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -153,6 +153,12 @@ services:
       - "logging=true"
     volumes:
       - ./config/form-content:/forms
+  mandataris:
+    image: lblod/mandataris-service:latest
+    labels:
+      - "logging=true"
+    restart: always
+    logging: *default-logging
   adressenregister:
     image: lblod/adressenregister-fuzzy-search-service:0.6.3
     labels:


### PR DESCRIPTION
## Description
This adds the new mandataris service (https://github.com/lblod/mandataris-service) to the app. The service doesn't do anything yet.

## How to test

Your app starts when the mandataris service is used (be sure to use the right profile if using the dev compose)

