### PR TITLE
add new service to track modification date on all interesting concepts

### DIFF
--- a/config/delta/modified.js
+++ b/config/delta/modified.js
@@ -1,0 +1,18 @@
+export default [
+  {
+    match: {
+      subject: {},
+    },
+    callback: {
+      url: "http://modified/delta",
+      method: "POST",
+    },
+    options: {
+      resourceFormat: "v0.0.1",
+      gracePeriod: 10000,
+      retry: 3,
+      ignoreFromSelf: true,
+      retryTimeout: 250,
+    },
+  },
+];

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -1,4 +1,5 @@
 import resource from "./resource";
 import ldes from "./ldes";
+import modified from "./modified";
 
-export default [...resource, ...ldes];
+export default [...resource, ...ldes, ...modified];

--- a/config/modified/config.ts
+++ b/config/modified/config.ts
@@ -1,0 +1,47 @@
+import { Changeset } from "../types";
+
+export const interestingTypes = [
+  "http://data.vlaanderen.be/ns/mandaat#Mandataris",
+  "http://data.vlaanderen.be/ns/mandaat#Fractie",
+  "http://data.vlaanderen.be/ns/persoon#Geboorte",
+  "http://www.w3.org/ns/org#Membership",
+  "http://data.vlaanderen.be/ns/mandaat#Mandaat",
+  "http://mu.semte.ch/vocabularies/ext/BeleidsdomeinCode",
+  "http://www.w3.org/ns/person#Person",
+  "http://purl.org/dc/terms/PeriodOfTime",
+  "http://www.w3.org/ns/adms#Identifier",
+  "http://data.vlaanderen.be/ns/besluit#Bestuursorgaan",
+  "http://data.lblod.info/vocabularies/leidinggevenden/Bestuursfunctie",
+  "http://data.lblod.info/vocabularies/leidinggevenden/Functionaris",
+  "http://mu.semte.ch/vocabularies/ext/Installatievergadering",
+  "http://schema.org/ContactPoint",
+  "http://www.w3.org/ns/locn#Address",
+];
+
+export const filterModifiedSubjects = "";
+
+export async function filterDeltas(changeSets: Changeset[]) {
+  const modifiedPred = "http://purl.org/dc/terms/modified";
+  const subjectsWithModified = new Set();
+
+  const trackModifiedSubjects = (quad) => {
+    if (quad.predicate.value === modifiedPred) {
+      subjectsWithModified.add(quad.subject.value);
+    }
+  };
+  changeSets.map((changeSet) => {
+    changeSet.inserts.forEach(trackModifiedSubjects);
+    changeSet.deletes.forEach(trackModifiedSubjects);
+  });
+
+  const ignoredGraphPrefixes = ["http://mu.semte.ch/graphs/formHistory"];
+  const isGoodQuad = (quad) =>
+    !subjectsWithModified.has(quad.subject.value) &&
+    !ignoredGraphPrefixes.some((prefix) => quad.graph.value.startsWith(prefix));
+  return changeSets.map((changeSet) => {
+    return {
+      inserts: changeSet.inserts.filter(isGoodQuad),
+      deletes: changeSet.deletes.filter(isGoodQuad),
+    };
+  });
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -45,6 +45,9 @@ services:
     restart: "no"
   deltanotifier:
     restart: "no"
+    networks:
+      - default
+      - debug
   migrations:
     restart: "no"
   cache:
@@ -66,6 +69,11 @@ services:
     profiles:
       - nodebug
   mandataris:
+    restart: "no"
+    profiles:
+      - nodebug
+  modified:
+    image: lblod/track-modified-service:0.0.0
     restart: "no"
     profiles:
       - nodebug

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,6 +159,14 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+  modified:
+    image: lblod/track-modified-service:0.0.0
+    labels:
+      - "logging=true"
+    volumes:
+      - ./config/modified:/config
+    restart: always
+    logging: *default-logging
 
   ##############################################################################
   # LDES


### PR DESCRIPTION
## Description

adds a new service to track modification dates on all interesting concepts.
## How to test

- clone the https://github.com/lblod/track-modified-service repo for local dev and start it there, or disable the debug profile in the dev drc
- up the docker compose (restart the delta service)
- update a concept, e.g. mandataris
- see that things that are modified along the way (e.g. geboorte) also receive a modified even if we didn't add this through the frontend or the form content service
- see that there is no infinite loop of deltas going on that keep setting the modified date

