### PR TITLE
add authorization layer on top of ldes

### DIFF
--- a/config/authorization-wrapper/filter.js
+++ b/config/authorization-wrapper/filter.js
@@ -22,7 +22,7 @@ export async function isAuthorized(sessionUri) {
           a session:Session ;
           mu:uuid ?uuid ;
           dct:created ?created ;
-          muAccount:account ?account .
+          muAccount:account ?account ;
           muAccount:canActOnBehalfOf ext:abb .
       }
     } LIMIT 2

--- a/config/authorization-wrapper/filter.js
+++ b/config/authorization-wrapper/filter.js
@@ -1,6 +1,31 @@
 import * as mu from "mu";
 import * as mas from "@lblod/mu-auth-sudo";
 
+export async function isBasicAuthorized(user, key, _req) {
+  const checkLoginQuery = `
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+    PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/>
+    PREFIX wotSec: <https://www.w3.org/2019/wot/security#>
+    PREFIX lblodAuth: <http://lblod.data.gift/vocabularies/authentication/>
+    PREFIX pav: <http://purl.org/pav/>
+    PREFIX session: <http://mu.semte.ch/vocabularies/session/>
+    PREFIX oslc: <http://open-services.net/ns/core#>
+    PREFIX dct: <http://purl.org/dc/terms/>
+    SELECT DISTINCT ?organizationID WHERE  {
+      ${mu.sparqlEscapeUri(user)}
+        a foaf:Agent;
+        muAccount:key ${mu.sparqlEscapeString(key)};
+        muAccount:canActOnBehalfOf <http://mu.semte.ch/vocabularies/ext/abb>.
+    }
+  `;
+  const response = await mas.querySudo(checkLoginQuery);
+  const exists = response.results?.bindings?.length > 0;
+  return exists;
+}
+
 export async function isAuthorized(sessionUri) {
   const checkSessionQuery = `
     PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>

--- a/config/authorization-wrapper/filter.js
+++ b/config/authorization-wrapper/filter.js
@@ -1,0 +1,34 @@
+import * as mu from "mu";
+import * as mas from "@lblod/mu-auth-sudo";
+
+export async function isAuthorized(sessionUri) {
+  const checkSessionQuery = `
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+    PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/>
+    PREFIX wotSec: <https://www.w3.org/2019/wot/security#>
+    PREFIX lblodAuth: <http://lblod.data.gift/vocabularies/authentication/>
+    PREFIX pav: <http://purl.org/pav/>
+    PREFIX session: <http://mu.semte.ch/vocabularies/session/>
+    PREFIX oslc: <http://open-services.net/ns/core#>
+    PREFIX dct: <http://purl.org/dc/terms/>
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+    SELECT ?uuid ?created ?account {
+      GRAPH ?g {
+        ${mu.sparqlEscapeUri(sessionUri)}
+          a session:Session ;
+          mu:uuid ?uuid ;
+          dct:created ?created ;
+          muAccount:account ?account .
+          muAccount:canActOnBehalfOf ext:abb .
+      }
+    } LIMIT 2
+  `;
+  const response = await mas.querySudo(checkSessionQuery);
+  // We want exactly one result, only one session should exist at a certain time.
+  const exists = response.results?.bindings?.length === 1;
+  return exists;
+}

--- a/config/authorization-wrapper/router.js
+++ b/config/authorization-wrapper/router.js
@@ -1,0 +1,4 @@
+export const router = {
+  "/abb": "http://ldes-backend:80",
+  "/internal": "http://ldes-backend:80",
+};

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -335,6 +335,13 @@ defmodule Dispatcher do
   #################################################################
   # LDES
   #################################################################
+  get "/streams/ldes/abb/*path" do
+    forward(conn, path, "http://authorization-wrapper/abb/")
+  end
+  get "/streams/ldes/internal/*path" do
+    forward(conn, path, "http://authorization-wrapper/internal/")
+  end
+
   get "/streams/ldes/*path" do
     forward(conn, path, "http://ldes-backend")
   end

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -73,7 +73,6 @@ services:
     profiles:
       - nodebug
   modified:
-    image: lblod/track-modified-service:0.0.0
     restart: "no"
     profiles:
       - nodebug
@@ -92,6 +91,8 @@ services:
   vendor-login:
     restart: "no"
   sparql-authorization-wrapper:
+    restart: "no"
+  authorization-wrapper:
     restart: "no"
   ##############################################################################
   # Besluiten consumers

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -85,7 +85,7 @@ services:
   ldes-backend:
     restart: "no"
     environment:
-      BASE_URL: "http://localhost/streams/ldes"
+      BASE_URL: "http://localhost/streams/ldes/"
     ports:
       - "6666:80"
   vendor-login:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,6 +168,14 @@ services:
     restart: always
     logging: *default-logging
 
+  authorization-wrapper:
+    image: local-authorization-wrapper
+    labels:
+      - "logging=true"
+    restart: always
+    logging: *default-logging
+    volumes:
+      - ./config/authorization-wrapper:/config
   ##############################################################################
   # LDES
   ##############################################################################

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -169,7 +169,7 @@ services:
     logging: *default-logging
 
   authorization-wrapper:
-    image: local-authorization-wrapper
+    image: lblod/ldes-authorization-wrapper:0.0.0
     labels:
       - "logging=true"
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -169,7 +169,7 @@ services:
     logging: *default-logging
 
   authorization-wrapper:
-    image: lblod/ldes-authorization-wrapper:0.0.0
+    image: lblod/ldes-authorization-wrapper:0.0.2
     labels:
       - "logging=true"
     restart: always

--- a/queries/vendor-access/add-vendor-key.sparql
+++ b/queries/vendor-access/add-vendor-key.sparql
@@ -7,6 +7,9 @@ PREFIX bestuurseenheid: <http://data.lblod.info/id/bestuurseenheden/>
 INSERT DATA {
   GRAPH <http://mu.semte.ch/graphs/automatic-submission> {
    <http://data.lblod.info/vendors/c5da766f-f1a6-426a-9a4d-36b96a855e18> muAccount:key "my super secret key that i should replace" .
+   <http://data.lblod.info/vendors/c5da766f-f1a6-426a-9a4d-36b96a855e18> muAccount:canActOnBehalfOf ext:abb .
+
+   ext:abb mu:uuid "a4d0e269-35ca-4f0f-be44-c836d0f3f5b7" .
   }
 }
 


### PR DESCRIPTION
## Description

Adds an authorization layer on top of our ldes feed. That way only the public ldes is publically accessible and to use the abb or internal ldes instances you need to be signed in with a user that has the right impersonation rights. Currently both abb and internal are the same one.

## How to test

Try and access the public, abb and internal ldes streams page 1. Notice that it only works for the public one.
Run the example query to give the demo vendor access to these endpoints.
Use the vendor login process to log in as an authorized user. Then access all of those pages again and notice they all work.

Here is a postman collection that allows you to perform these steps:
[ldes example.json](https://github.com/lblod/app-lokaal-mandatenbeheer/files/15296330/ldes.example.json)
