### PR TITLE
Bump mandataris service to 0.0.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,7 +151,7 @@ services:
     volumes:
       - ./config/form-content:/config
   mandataris:
-    image: lblod/mandataris-service:0.0.2
+    image: lblod/mandataris-service:0.0.3
     labels:
       - "logging=true"
     restart: always


### PR DESCRIPTION
## Description

Bump to 0.0.3 because this version does have a related docker hub image. It is functionally the same as 0.0.2

## How to test

Walk through the app and see if all mandataris related functionality still works

## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/153
