### PR TITLE
LMB-147: Add restrictions to forms

### DIFF
--- a/config/form-content/bestuursorgaan-ext-example/form.ttl
+++ b/config/form-content/bestuursorgaan-ext-example/form.ttl
@@ -14,14 +14,30 @@ ext:emailF
     ext:extendsGroup ext:bestuursorgaanPG;
     sh:name "Email";
     sh:order 301;
-    sh:path schema:email.
+    sh:path schema:email;
+    form:validatedBy
+        [ 
+            a form:ValidEmail;
+            form:grouping form:MatchEvery;
+            sh:order 1;
+            sh:resultMessage "Geef een geldig e-mailadres op."@nl;
+            sh:path schema:email
+    ].
 ext:telefoonF
     a form:Field;
     form:displayType displayTypes:defaultInput;
     ext:extendsGroup ext:bestuursorgaanPG;
     sh:name "Telefoon";
     sh:order 302;
-    sh:path schema:telephone.
+    sh:path schema:telephone;
+    form:validatedBy
+        [
+            a form:ValidPhoneNumber;
+            form:defaultCountry "BE";
+            form:grouping form:MatchEvery;
+            sh:path schema:telephone;
+            sh:resultMessage "Geef een geldig telefoonnummer in."
+    ].
 ext:adresF
     a form:Field;
     form:displayType displayTypes:addressSelector;
@@ -36,7 +52,14 @@ ext:statusF
     sh:name "Status";
     sh:order 304;
     sh:path mandaat:status;
-    form:options """{"conceptScheme":"http://mu.semte.ch/vocabularies/ext/FunctionarisStatusCode","searchEnabled":false}""".
+    form:options """{"conceptScheme":"http://mu.semte.ch/vocabularies/ext/FunctionarisStatusCode","searchEnabled":false}""";
+    form:validatedBy 
+        [
+            a form:RequiredConstraint;
+            form:grouping form:Bag;
+            sh:path mandaat:status;
+            sh:resultMessage "Status is verplicht."
+    ].
 
 <http://data.lblod.info/id/lmb/forms/bestuursorgaan-ext-example>
     a form:Extension;

--- a/config/form-content/bestuursorgaan/form.ttl
+++ b/config/form-content/bestuursorgaan/form.ttl
@@ -31,7 +31,7 @@ ext:bestuursorgaanClassificatieCodeF
     sh:group ext:bestuursorgaanPG;
     sh:name "Type";
     sh:order 2;
-    sh:path besluit:classificatie;
+    sh:path <http://data.vlaanderen.be/ns/besluit#classificatie>;
     form:options """{"conceptScheme":"http://mu.semte.ch/vocabularies/ext/lmb/vrije-bestuursorgaan-codes","searchEnabled":true}""".
 ext:deactivatedAtF
     a form:Field;

--- a/config/form-content/bestuursorgaan/form.ttl
+++ b/config/form-content/bestuursorgaan/form.ttl
@@ -17,15 +17,29 @@ ext:naamF
     sh:group ext:bestuursorgaanPG;
     sh:name "Naam";
     sh:order 1;
-    sh:path skos:prefLabel.
+    sh:path skos:prefLabel;
+    form:validatedBy 
+        [
+            a form:RequiredConstraint;
+            form:grouping form:Bag;
+            sh:path skos:prefLabel;
+            sh:resultMessage "Naam is verplicht."
+    ].
 ext:bestuursorgaanClassificatieCodeF
     a form:Field;
     form:displayType displayTypes:conceptSchemeSelectorWithoutMeta;
     sh:group ext:bestuursorgaanPG;
     sh:name "Type";
     sh:order 2;
-    sh:path <http://data.vlaanderen.be/ns/besluit#classificatie>;
-    form:options """{"conceptScheme":"http://mu.semte.ch/vocabularies/ext/lmb/vrije-bestuursorgaan-codes","searchEnabled":true}""".
+    sh:path besluit:classificatie;
+    form:options """{"conceptScheme":"http://mu.semte.ch/vocabularies/ext/lmb/vrije-bestuursorgaan-codes","searchEnabled":true}""";
+    form:validatedBy 
+        [
+            a form:RequiredConstraint;
+            form:grouping form:Bag;
+            sh:path besluit:classificatie;
+            sh:resultMessage "Type is verplicht."
+    ].
 ext:deactivatedAtF
     a form:Field;
     form:displayType displayTypes:archivedInput;

--- a/config/form-content/bestuursorgaan/form.ttl
+++ b/config/form-content/bestuursorgaan/form.ttl
@@ -32,14 +32,7 @@ ext:bestuursorgaanClassificatieCodeF
     sh:name "Type";
     sh:order 2;
     sh:path besluit:classificatie;
-    form:options """{"conceptScheme":"http://mu.semte.ch/vocabularies/ext/lmb/vrije-bestuursorgaan-codes","searchEnabled":true}""";
-    form:validatedBy 
-        [
-            a form:RequiredConstraint;
-            form:grouping form:Bag;
-            sh:path besluit:classificatie;
-            sh:resultMessage "Type is verplicht."
-    ].
+    form:options """{"conceptScheme":"http://mu.semte.ch/vocabularies/ext/lmb/vrije-bestuursorgaan-codes","searchEnabled":true}""".
 ext:deactivatedAtF
     a form:Field;
     form:displayType displayTypes:archivedInput;

--- a/config/form-content/bestuursperiode/form.ttl
+++ b/config/form-content/bestuursperiode/form.ttl
@@ -18,7 +18,14 @@ ext:bindingStartF
     sh:group ext:bestuursperiodePG;
     sh:name "Start";
     sh:order 2;
-    sh:path mandaat:bindingStart.
+    sh:path mandaat:bindingStart;
+    form:validatedBy 
+        [
+            a form:RequiredConstraint;
+            form:grouping form:Bag;
+            sh:path mandaat:bindingStart;
+            sh:resultMessage "Startdatum is verplicht."
+    ].
 ext:bindingEindeF
     a form:Field;
     form:displayType displayTypes:dateTime;

--- a/config/form-content/contactinfo/form.ttl
+++ b/config/form-content/contactinfo/form.ttl
@@ -12,14 +12,30 @@ ext:emailF
     sh:group ext:contactpuntPG;
     sh:name "Email";
     sh:order 2;
-    sh:path schema:email.
+    sh:path schema:email;
+    form:validatedBy
+        [
+            a form:ValidEmail;
+            form:grouping form:MatchEvery;
+            sh:order 1;
+            sh:resultMessage "Geef een geldig e-mailadres op."@nl;
+            sh:path schema:email
+    ].
 ext:telefoonF
     a form:Field;
     form:displayType displayTypes:defaultInput;
     sh:group ext:contactpuntPG;
     sh:name "Telefoon";
     sh:order 3;
-    sh:path schema:telephone.
+    sh:path schema:telephone;
+    form:validatedBy
+        [
+            a form:ValidPhoneNumber;
+            form:defaultCountry "BE";
+            form:grouping form:MatchEvery;
+            sh:path schema:telephone;
+            sh:resultMessage "Geef een geldig telefoonnummer in."
+    ].
 ext:adresF
     a form:Field;
     form:displayType displayTypes:addressSelector;

--- a/config/form-content/functionaris-edit/form.ttl
+++ b/config/form-content/functionaris-edit/form.ttl
@@ -12,7 +12,14 @@ ext:startF
     sh:group ext:functionarisEditPG;
     sh:name "Start aanstellingsperiode";
     sh:order 2;
-    sh:path mandaat:start.
+    sh:path mandaat:start;
+    form:validatedBy 
+        [
+            a form:RequiredConstraint;
+            form:grouping form:Bag;
+            sh:path mandaat:start;
+            sh:resultMessage "Startdatum is verplicht."
+    ].
 ext:eindeF
     a form:Field;
     form:displayType displayTypes:dateTime;
@@ -27,7 +34,14 @@ ext:statusF
     sh:name "Status";
     sh:order 4;
     sh:path mandaat:status;
-    form:options """{"conceptScheme":"http://mu.semte.ch/vocabularies/ext/FunctionarisStatusCode","searchEnabled":false}""".
+    form:options """{"conceptScheme":"http://mu.semte.ch/vocabularies/ext/FunctionarisStatusCode","searchEnabled":false}""";
+    form:validatedBy 
+        [
+            a form:RequiredConstraint;
+            form:grouping form:Bag;
+            sh:path mandaat:status;
+            sh:resultMessage "Status is verplicht."
+    ].
 ext:functionarisEditPG
     a form:PropertyGroup; sh:name "Functie"; sh:order 1.
 

--- a/config/form-content/functionaris-new/form.ttl
+++ b/config/form-content/functionaris-new/form.ttl
@@ -20,7 +20,14 @@ ext:startF
     sh:group ext:functionarisEditPG;
     sh:name "Start aanstellingsperiode";
     sh:order 3;
-    sh:path mandaat:start.
+    sh:path mandaat:start;
+    form:validatedBy 
+        [
+            a form:RequiredConstraint;
+            form:grouping form:Bag;
+            sh:path mandaat:start;
+            sh:resultMessage "Startdatum is verplicht."
+    ].
 ext:eindeF
     a form:Field;
     form:displayType displayTypes:dateTime;
@@ -35,7 +42,14 @@ ext:statusF
     sh:name "Status";
     sh:order 5;
     sh:path mandaat:status;
-    form:options """{"conceptScheme":"http://mu.semte.ch/vocabularies/ext/FunctionarisStatusCode","searchEnabled":false}""".
+    form:options """{"conceptScheme":"http://mu.semte.ch/vocabularies/ext/FunctionarisStatusCode","searchEnabled":false}""";
+    form:validatedBy 
+        [
+            a form:RequiredConstraint;
+            form:grouping form:Bag;
+            sh:path mandaat:status;
+            sh:resultMessage "Status is verplicht."
+    ].
 ext:functionarisEditPG
     a form:PropertyGroup; sh:name "Functie"; sh:order 1.
 

--- a/config/form-content/mandaat/form.ttl
+++ b/config/form-content/mandaat/form.ttl
@@ -15,7 +15,13 @@ ext:aantalHoudersF
     sh:group ext:mandaatPG;
     sh:name "Aantal houders";
     sh:order 2;
-    sh:path mandaat:aantalHouders.
+    sh:path mandaat:aantalHouders;
+    form:validatedBy [
+      a form:PositiveNumber ;
+      form:grouping form:MatchEvery ;
+      sh:resultMessage "Je kan hier geen negatief getal ingeven." ;
+      sh:path mandaat:aantalHouders ;
+    ].
 ext:mandaatPG
     a form:PropertyGroup; sh:name "Mandaat"; sh:order 1.
 

--- a/config/form-content/mandataris-edit/form.ttl
+++ b/config/form-content/mandataris-edit/form.ttl
@@ -24,7 +24,14 @@ ext:mandatarisStatusCodeF
     sh:name "Status";
     sh:order 300;
     sh:path mandaat:status;
-    form:options """{"conceptScheme":"http://data.vlaanderen.be/id/conceptscheme/MandatarisStatusCode","searchEnabled":true}""".
+    form:options """{"conceptScheme":"http://data.vlaanderen.be/id/conceptscheme/MandatarisStatusCode","searchEnabled":true}""";
+    form:validatedBy 
+        [
+            a form:RequiredConstraint;
+            form:grouping form:Bag;
+            sh:path mandaat:status;
+            sh:resultMessage "Status is verplicht."
+    ].
 ext:replacementF
     a form:Field;
     form:displayType displayTypes:mandatarisReplacement;
@@ -52,7 +59,14 @@ ext:startF
     sh:group ext:editMandatarisPG;
     sh:name "Start";
     sh:order 700;
-    sh:path mandaat:start.
+    sh:path mandaat:start;
+    form:validatedBy 
+        [
+            a form:RequiredConstraint;
+            form:grouping form:Bag;
+            sh:path mandaat:start;
+            sh:resultMessage "Start datum is verplicht."
+    ].
 ext:eindeF
     a form:Field;
     form:displayType displayTypes:dateTime;
@@ -66,7 +80,14 @@ ext:fractieF
     sh:group ext:editMandatarisPG;
     sh:name "Fractie";
     sh:order 900;
-    sh:path ( org:hasMembership org:organisation ).
+    sh:path ( org:hasMembership org:organisation );
+    form:validatedBy 
+        [
+            a form:RequiredConstraint;
+            form:grouping form:Bag;
+            sh:path ( org:hasMembership org:organisation );
+            sh:resultMessage "Dit veld is verplicht."
+    ].
 ext:linkTobesluitF
     a form:Field;
     form:displayType displayTypes:defaultInput;

--- a/config/form-content/mandataris-edit/form.ttl
+++ b/config/form-content/mandataris-edit/form.ttl
@@ -65,7 +65,7 @@ ext:startF
             a form:RequiredConstraint;
             form:grouping form:Bag;
             sh:path mandaat:start;
-            sh:resultMessage "Start datum is verplicht."
+            sh:resultMessage "Startdatum is verplicht."
     ].
 ext:eindeF
     a form:Field;

--- a/config/form-content/mandataris-new/form.ttl
+++ b/config/form-content/mandataris-new/form.ttl
@@ -66,7 +66,7 @@ ext:startF
             a form:RequiredConstraint;
             form:grouping form:Bag;
             sh:path mandaat:start;
-            sh:resultMessage "Start datum is verplicht."
+            sh:resultMessage "Startdatum is verplicht."
     ].
 ext:eindeF
     a form:Field;

--- a/config/form-content/mandataris-new/form.ttl
+++ b/config/form-content/mandataris-new/form.ttl
@@ -32,7 +32,14 @@ ext:mandatarisStatusCodeF
     sh:name "Status";
     sh:order 4;
     sh:path mandaat:status;
-    form:options """{"conceptScheme":"http://data.vlaanderen.be/id/conceptscheme/MandatarisStatusCode","searchEnabled":true}""".
+    form:options """{"conceptScheme":"http://data.vlaanderen.be/id/conceptscheme/MandatarisStatusCode","searchEnabled":true}""";
+    form:validatedBy 
+        [
+            a form:RequiredConstraint;
+            form:grouping form:Bag;
+            sh:path mandaat:status;
+            sh:resultMessage "Status is verplicht."
+    ].
 ext:rangordeF
     a form:Field;
     form:displayType displayTypes:mandatarisRangorde;
@@ -53,7 +60,14 @@ ext:startF
     sh:group ext:mandatarisPG;
     sh:name "Start";
     sh:order 7;
-    sh:path mandaat:start.
+    sh:path mandaat:start;
+    form:validatedBy 
+        [
+            a form:RequiredConstraint;
+            form:grouping form:Bag;
+            sh:path mandaat:start;
+            sh:resultMessage "Start datum is verplicht."
+    ].
 ext:eindeF
     a form:Field;
     form:displayType displayTypes:dateTime;
@@ -67,7 +81,14 @@ ext:fractieF
     sh:group ext:mandatarisPG;
     sh:name "Fractie";
     sh:order 9;
-    sh:path ( org:hasMembership org:organisation ).
+    sh:path ( org:hasMembership org:organisation );
+    form:validatedBy 
+        [
+            a form:RequiredConstraint;
+            form:grouping form:Bag;
+            sh:path ( org:hasMembership org:organisation );
+            sh:resultMessage "Dit veld is verplicht."
+    ].
 ext:mandatarisPG
     a form:PropertyGroup; sh:name ""; sh:order 1.
 

--- a/config/form-content/persoon/form.ttl
+++ b/config/form-content/persoon/form.ttl
@@ -18,14 +18,28 @@ ext:gebruikteVoornaamF
     sh:group ext:persoonPG;
     sh:name "Voornaam";
     sh:order 2;
-    sh:path persoon:gebruikteVoornaam.
+    sh:path persoon:gebruikteVoornaam;
+    form:validatedBy 
+        [
+            a form:RequiredConstraint;
+            form:grouping form:Bag;
+            sh:path persoon:gebruikteVoornaam;
+            sh:resultMessage "Voornaam is verplicht."
+    ].
 ext:achternaamF
     a form:Field;
     form:displayType displayTypes:defaultInput;
     sh:group ext:persoonPG;
     sh:name "Achternaam";
     sh:order 3;
-    sh:path foaf:familyName.
+    sh:path foaf:familyName;
+    form:validatedBy 
+        [
+            a form:RequiredConstraint;
+            form:grouping form:Bag;
+            sh:path foaf:familyName;
+            sh:resultMessage "Achternaam is verplicht."
+    ].
 ext:alternatieveNaamF
     a form:Field;
     form:displayType displayTypes:defaultInput;


### PR DESCRIPTION
## Description

A lot of entities are created through forms, as some fields need to be required or must be positive values these need to be updated with some constraints.

Tim wrote a mail with the required validations => see mailbox `Restricties op form fields` op 28-05-24

## How to test

Follow the email and see if all validations are added to the application

## Attachments

Aantal houders cannot be negative

![image](https://github.com/lblod/app-lokaal-mandatenbeheer/assets/36266973/4ffcfe7a-8d6c-4024-9451-b5ac5fd0fc27)

Update or create mandataris has three more constraints

![image](https://github.com/lblod/app-lokaal-mandatenbeheer/assets/36266973/c0960b5e-ba98-4fff-9112-4cabcc00fc5a)
