### PR TITLE
LMB-237: Remove form:targetType from the extension forms

### DIFF
--- a/config/form-content/bestuursorgaan-ext-example/form.ttl
+++ b/config/form-content/bestuursorgaan-ext-example/form.ttl
@@ -46,7 +46,6 @@ ext:statusF
         ext:adresF,
         ext:statusF;
     ext:extendsForm <http://data.lblod.info/id/lmb/forms/bestuursorgaan>;
-    form:targetType besluit:Bestuursorgaan;
     form:targetLabel schema:email;
     ext:prefix <http://data.lblod.info/id/bestuursorgaan-ext-examples/>;
     mu:uuid "630891b2-6086-4b36-9e88-982fd32b57e0".

--- a/config/form-content/bestuursorgaan-ext-ext-example/form.ttl
+++ b/config/form-content/bestuursorgaan-ext-ext-example/form.ttl
@@ -29,7 +29,6 @@ ext:geslachtCodeF
         ext:testF,
         ext:geslachtCodeF;
     ext:extendsForm <http://data.lblod.info/id/lmb/forms/bestuursorgaan-ext-example>;
-    form:targetType besluit:Bestuursorgaan;
     form:targetLabel skos:prefLabel;
     ext:prefix <http://data.lblod.info/id/bestuursorgaan-ext-ext-examples/>;
     mu:uuid "3d4c9725-4a31-40b5-acaa-90bd6dcae13d".


### PR DESCRIPTION
## Description

We do not want to set the `targetType` and `targetLabel` in the extensions forms.

## How to test

 - /

## Links to other PR's

- https://github.com/lblod/form-content-service/pull/56
