### PR TITLE
Ben/lmb 574 beeindigd migration

### DIFF
--- a/config/migrations/2024/20240626161836-beeindigd-status.sparql
+++ b/config/migrations/2024/20240626161836-beeindigd-status.sparql
@@ -13,7 +13,7 @@ INSERT DATA {
       rdf:type
         skos:Concept,
         ext:MandatarisStatusCode;
-	    skos:prefLabel "Beeindigd";
+	    skos:prefLabel "Beëindigd";
 	    mu:uuid "b8866fa2-d61c-4e3d-afaf-8a29eaaa7fb9".
   }
 }

--- a/config/migrations/2024/20240626161836-beeindigd-status.sparql
+++ b/config/migrations/2024/20240626161836-beeindigd-status.sparql
@@ -1,0 +1,19 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX cs: <http://data.vlaanderen.be/id/conceptscheme/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX ext:	<http://mu.semte.ch/vocabularies/ext/>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX msc: <http://data.vlaanderen.be/id/concept/MandatarisStatusCode/>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    msc:b8866fa2-d61c-4e3d-afaf-8a29eaaa7fb9
+	    skos:topConceptOf	cs:MandatarisStatusCode;
+	    skos:inScheme	cs:MandatarisStatusCode;
+      rdf:type
+        skos:Concept,
+        ext:MandatarisStatusCode;
+	    skos:prefLabel "Beeindigd";
+	    mu:uuid "b8866fa2-d61c-4e3d-afaf-8a29eaaa7fb9".
+  }
+}


### PR DESCRIPTION
## Description

The addition of the mandataris status code beeindigd is now a migration. Makes it possible to access this in other places, such as the mandataris service.

## How to test

You can run the following query to see if the beeindigd mandataris status code exists in the database:
`select * where { ?s  a <http://mu.semte.ch/vocabularies/ext/MandatarisStatusCode>.
 ?s ?p ?o.
}`

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/256
