### PR TITLE
Add binding end for bestuursorganenInTijd in current and previous bestuursperiode

### DIFF
--- a/config/migrations/2024/20240627000000-update-bestuursorganen-binding-end.sparql
+++ b/config/migrations/2024/20240627000000-update-bestuursorganen-binding-end.sparql
@@ -1,0 +1,34 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX bestuursperiode: <http://data.lblod.info/id/concept/Bestuursperiode/>
+
+DELETE {
+    GRAPH ?g {
+		?bestuursorgaanInTijd mandaat:bindingEinde ?einde.
+    }
+} INSERT {
+    GRAPH ?g {
+		?bestuursorgaanInTijd mandaat:bindingEinde "2024-12-06"^^xsd:date.
+    }
+}
+WHERE {
+    GRAPH ?g {
+        ?bestuursorgaanInTijd ext:heeftBestuursperiode bestuursperiode:a2b977a3-ce68-4e42-80a6-4397f66fc5ca. # 2019 - 2025
+    }
+};
+
+DELETE {
+    GRAPH ?g {
+		?bestuursorgaanInTijd mandaat:bindingEinde ?einde.
+    }
+} INSERT {
+    GRAPH ?g {
+		?bestuursorgaanInTijd mandaat:bindingEinde "2030-12-06"^^xsd:date.
+    }
+}
+WHERE {
+    GRAPH ?g {
+        ?bestuursorgaanInTijd ext:heeftBestuursperiode bestuursperiode:96efb929-5d83-48fa-bfbb-b98dfb1180c7. # 2025 - 2030
+    }
+};

--- a/config/migrations/2024/20240627000000-update-bestuursorganen-binding-end.sparql
+++ b/config/migrations/2024/20240627000000-update-bestuursorganen-binding-end.sparql
@@ -15,6 +15,9 @@ DELETE {
 WHERE {
     GRAPH ?g {
         ?bestuursorgaanInTijd ext:heeftBestuursperiode bestuursperiode:a2b977a3-ce68-4e42-80a6-4397f66fc5ca. # 2019 - 2025
+        OPTIONAL {
+          ?bestuursorgaanInTijd mandaat:bindingEinde ?einde.
+        }
     }
 };
 
@@ -30,5 +33,8 @@ DELETE {
 WHERE {
     GRAPH ?g {
         ?bestuursorgaanInTijd ext:heeftBestuursperiode bestuursperiode:96efb929-5d83-48fa-bfbb-b98dfb1180c7. # 2025 - 2030
+        OPTIONAL {
+          ?bestuursorgaanInTijd mandaat:bindingEinde ?einde.
+        }
     }
 };


### PR DESCRIPTION
## Description

Our bestuursorganen(InTijd) need a more accurate end date. This is the case for the current and previous bestuursperiode.

## How to test

Run the following querries (separately) to see the updated `bindingEinde`s for the bestuursorganenInTijd of both bestuursperiodes.

```sparql
PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
PREFIX bestuursperiode: <http://data.lblod.info/id/concept/Bestuursperiode/>

SELECT *
WHERE {
    GRAPH ?g {
        ?bestuursorgaanInTijd ext:heeftBestuursperiode bestuursperiode:a2b977a3-ce68-4e42-80a6-4397f66fc5ca; # 2019 - 2025
         mandaat:bindingStart ?bindingStart;
         mandaat:bindingEinde ?bindingEinde.
    }
}

SELECT *
WHERE {
    GRAPH ?g {
        ?bestuursorgaanInTijd ext:heeftBestuursperiode bestuursperiode:96efb929-5d83-48fa-bfbb-b98dfb1180c7; # 2025 - 2030
         mandaat:bindingStart ?bindingStart;
         mandaat:bindingEinde ?bindingEinde.
    }
}
```
