### PR TITLE
Migration to update burgemeester status verhinderd to titelvoerend

### DIFF
--- a/config/migrations/2024/20240704115947-replace-verhinderd-titelvoerend.sparql
+++ b/config/migrations/2024/20240704115947-replace-verhinderd-titelvoerend.sparql
@@ -1,0 +1,21 @@
+prefix mandaat:	<http://data.vlaanderen.be/ns/mandaat#> 
+prefix org: <http://www.w3.org/ns/org#>
+
+DELETE {
+  GRAPH ?g {
+      ?mandataris mandaat:status <http://data.vlaanderen.be/id/concept/MandatarisStatusCode/c301248f-0199-45ca-b3e5-4c596731d5fe>.
+  }
+}
+INSERT {
+  GRAPH ?g {
+      ?mandataris mandaat:status <http://data.vlaanderen.be/id/concept/MandatarisStatusCode/aacb3fed-b51d-4e0b-a411-f3fa641da1b3>.
+  }
+}
+WHERE {
+  GRAPH ?g {
+      ?mandataris org:holds ?mandaat;
+            mandaat:status <http://data.vlaanderen.be/id/concept/MandatarisStatusCode/c301248f-0199-45ca-b3e5-4c596731d5fe>.
+      ?mandaat org:role ?bestuursfunctieCode.
+      FILTER (?bestuursfunctieCode IN (<http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000013>, <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/7b038cc40bba10bec833ecfe6f15bc7a>)).
+  }
+}


### PR DESCRIPTION
## Description

Currently we only allow users in the frontend to set the status titelvoerend on a mandate, verhinderd is no longer possible. This migration also updates old data in our application where burgemeester could still have the status verhinderd.

## How to test

Two possible tests:
Go to the following link in the gemeente Aalst and see that the status of this burgemeester is indeed titelvoerend, before running the migration it was verhinderd.
You could also check this query no longer has results (this is a bit cheating however, since this exact query is used to update the statusses...):
```
prefix mandaat:	<http://data.vlaanderen.be/ns/mandaat#> 
prefix org: <http://www.w3.org/ns/org#>

SELECT DISTINCT *
WHERE {
  GRAPH ?g {
      ?mandataris org:holds ?mandaat;
            mandaat:status <http://data.vlaanderen.be/id/concept/MandatarisStatusCode/c301248f-0199-45ca-b3e5-4c596731d5fe>.
      ?mandaat org:role ?bestuursfunctieCode.
      FILTER (?bestuursfunctieCode IN (<http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000013>, <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/7b038cc40bba10bec833ecfe6f15bc7a>)).
  }
}
```
