### PR TITLE
create new uuids fake ocmw bestuursorganen

### DIFF
--- a/config/migrations/2024/20240703001144-tmp-ocmw-bestuursorganen.sparql
+++ b/config/migrations/2024/20240703001144-tmp-ocmw-bestuursorganen.sparql
@@ -11,13 +11,13 @@ INSERT {
   GRAPH ?k {
     ?bestuursorgaanURI besluit:bestuurt ?bestuurseenheidGemeente;
           a besluit:Bestuursorgaan;  
-          mu:uuid ?bestuursorgaanId;  
+          mu:uuid ?uuid;  
           ext:origineleBestuurseenheid ?bestuurseenheidOCMW;
           skos:prefLabel ?naam;
           besluit:classificatie ?classificatie.
     ?bestuursorgaanInTijdURI mandaat:isTijdspecialisatieVan ?bestuursorgaanURI;
           a besluit:Bestuursorgaan;  
-          mu:uuid ?bestuursorgaanInTijdId;  
+          mu:uuid ?uuidInTijd;  
           ext:origineleBestuursorgaan ?bestuursorgaanInTijd;
           ext:heeftBestuursperiode ?bestuursperiode;
           org:hasPost ?mandaat.

--- a/config/migrations/2024/20240703001144-tmp-ocmw-bestuursorganen.sparql
+++ b/config/migrations/2024/20240703001144-tmp-ocmw-bestuursorganen.sparql
@@ -53,6 +53,8 @@ WHERE {
   GRAPH ?k {
     ?bestuursorgaan2 besluit:bestuurt ?bestuurseenheidGemeente.
   }
-  BIND(URI(CONCAT("http://data.lblod.info/id/bestuursorganen-fake/", ?bestuursorgaanId)) AS ?bestuursorgaanURI).
-  BIND(URI(CONCAT("http://data.lblod.info/id/bestuursorganen-fake/", ?bestuursorgaanInTijdId)) AS ?bestuursorgaanInTijdURI).
+  BIND(SHA256(CONCAT("7dcad3b3-23c8-46e9-8375-2d0ddd3d2b11", ":", STR(?bestuursorgaanId))) AS ?uuid) .
+  BIND(SHA256(CONCAT("87fb8e46-71ed-4699-83a2-d9162ef65359", ":", STR(?bestuursorgaanInTijdId))) AS ?uuidInTijd) .
+  BIND(URI(CONCAT("http://data.lblod.info/id/bestuursorganen/", ?uuid)) AS ?bestuursorgaanURI).
+  BIND(URI(CONCAT("http://data.lblod.info/id/bestuursorganen/", ?uuidInTijd)) AS ?bestuursorgaanInTijdURI).
 }


### PR DESCRIPTION
## Description

Before fake ocmw bestuursorganen (bestuursorganen that normally belong to an ocmw bestuurseenheid, but are copied to the gemeente bestuurseenheid to prepare a new legislature) had the same id as their original bestuursorgaan. This is resolved in this PR by generating new uuids.

## How to test

Unfortunately you should again start with a clean database, but this is the last time I'm making updates to existing migrations.

If you run the following query, you should see that ids and uris of new bestuursorganen and bestuursorganen in de tijd are unique.
```
prefix mandaat:	<http://data.vlaanderen.be/ns/mandaat#> 
prefix besluit:	<http://data.vlaanderen.be/ns/besluit#> 
prefix ext: <http://mu.semte.ch/vocabularies/ext/>
prefix mu: <http://mu.semte.ch/vocabularies/core/>

SELECT DISTINCT ?bestuursorgaan ?bestuursorgaanURI ?bestuursorgaanId ?bestuursorgaanInTijd ?bestuursorgaanInTijdURI ?bestuursorgaanInTijdId WHERE {
    ?bestuursorgaanURI a besluit:Bestuursorgaan;  
          mu:uuid ?bestuursorgaanId;  
          ext:origineleBestuurseenheid ?bestuurseenheidOCMW.
    ?bestuursorgaanInTijdURI mandaat:isTijdspecialisatieVan ?bestuursorgaanURI;
          a besluit:Bestuursorgaan;  
          mu:uuid ?bestuursorgaanInTijdId;  
          ext:origineleBestuursorgaan ?bestuursorgaanInTijd.
      ?bestuursorgaanInTijd mandaat:isTijdspecialisatieVan ?bestuursorgaan.
  }
```
