### PR TITLE
LMB-524 | Only process mandatrissen with a besluit 

### DIFF
--- a/config/delta/decisions.js
+++ b/config/delta/decisions.js
@@ -1,14 +1,17 @@
 export default [
   {
     match: {
-      subject: {},
+      predicate: {
+        type: 'uri',
+        value: 'http://mu.semte.ch/vocabularies/ext/bekrachtigtAanstellingVan',
+      },
       graph: {
         type: 'uri',
         value: 'http://mu.semte.ch/graphs/besluiten-consumed',
       },
     },
     callback: {
-      url: 'http://mandataris/mandatees-decisions',
+      url: 'http://mandataris/delta/decisions',
       method: 'POST',
     },
     options: {

--- a/config/form-content/mandataris-edit/form.ttl
+++ b/config/form-content/mandataris-edit/form.ttl
@@ -98,11 +98,11 @@ ext:linkTobesluitF
         a form:UriConstraint;
         form:grouping form:MatchEvery;
         sh:order 1;
-        sh:path schema:url;
+        sh:path ext:linkToBesluit;
         sh:resultMessage
             "Gelieve een geldige URL op te geven. Zorg dat vooraan in de link altijd http://, https://, ftp:// of sftp:// staat."@nl
     ];
-    sh:path schema:url.
+    sh:path ext:linkToBesluit.
 ext:editMandatarisPG
     a form:PropertyGroup; sh:name ""; sh:order 1.
 

--- a/config/resources/external-mandaat.lisp
+++ b/config/resources/external-mandaat.lisp
@@ -80,7 +80,7 @@
                 (:datum-ministrieel-besluit :datetime ,(s-prefix "ext:datumMinistrieelBesluit"))
                 (:generated-from :uri-set ,(s-prefix "ext:generatedFrom")) ;;if it e.g. comes from gelinkt-notuleren
                 (:duplication-reason :string ,(s-prefix "skos:changeNote"))
-                (:link-to-besluit :string ,(s-prefix "schema:url"))
+                (:link-to-besluit :string ,(s-prefix "ext:linkToBesluit"))
                 (:modified :datetime ,(s-prefix "dct:modified")))
   :has-many `((mandataris :via ,(s-prefix "mandaat:isTijdelijkVervangenDoor")
                           :as "tijdelijke-vervangingen")


### PR DESCRIPTION
## Description

Updating the delta rule. Callback endpoint has changed in the mandataris service + we are now isting on the predicate `http://mu.semte.ch/vocabularies/ext/bekrachtigtAanstellingVan` so we get `?artikel <http://mu.semte.ch/vocabularies/ext/bekrachtigtAanstellingVan> ?mandataris` in our changesset of the delta.

## How to test

Run the app with the the mandataris service and the LMB app on the correct branches.

## Links to other PR's

- https://github.com/lblod/mandataris-service/pull/23