### PR TITLE
LMB-613 new mandataris form for prepare legislature

### DIFF
--- a/config/form-content/mandataris-ext/form.ttl
+++ b/config/form-content/mandataris-ext/form.ttl
@@ -1,0 +1,23 @@
+@prefix form: <http://lblod.data.gift/vocabularies/forms/> .
+@prefix sh: <http://www.w3.org/ns/shacl#>.
+@prefix mu: <http://mu.semte.ch/vocabularies/core/> .
+@prefix displayTypes: <http://lblod.data.gift/display-types/> .
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
+@prefix mandaat: <http://data.vlaanderen.be/ns/mandaat#> .
+
+ext:beleidsdomeinCodeF
+    a form:Field;
+    form:displayType displayTypes:mandatarisBeleidsdomein;
+    ext:extendsGroup ext:mandatarisPG;
+    sh:name "Beleidsdomein";
+    sh:order 100;
+    sh:path mandaat:beleidsdomein;
+    form:options """{"conceptScheme":"http://data.vlaanderen.be/id/conceptscheme/BeleidsdomeinCode","searchEnabled":true, "type":"beleidsdomein-code"}""".
+
+<http://data.lblod.info/id/lmb/forms/mandataris-ext>
+    a form:Extension;
+    form:includes
+        ext:beleidsdomeinCodeF;
+    ext:extendsForm <http://data.lblod.info/id/lmb/forms/mandataris-new>;
+    ext:withHistory false;
+    mu:uuid "01f671e2-df52-463d-9249-293e31eb7f54".


### PR DESCRIPTION
## Description

Add new form which extends the mandataris-new form with the beleidsdomeinen. These are only showed for the right mandates, due to the beleidsdomeinen custom component.

## How to test

Restart form-content service and check if the form is indeed in the forms route. If you try to create a new form entity with this form, you won't see the beleidsdomeinen, as the mandate selector does not really work in this route (no selected bestuursorgaan). You can see the beleidsdomeinen field in the form if you try to edit a mandataris which already has a mandate schepen or burgemeester. Or you can just try to test this with the installatievergadering redesign, which uses this form.

## Link to other PR's
- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/264