### PR TITLE
LMB-613 add new form with mandataris + beleidsdomeinen v2

### DIFF
--- a/config/form-content/mandataris-ext/form.ttl
+++ b/config/form-content/mandataris-ext/form.ttl
@@ -1,0 +1,138 @@
+@prefix form: <http://lblod.data.gift/vocabularies/forms/>.
+@prefix sh: <http://www.w3.org/ns/shacl#>.
+@prefix mu: <http://mu.semte.ch/vocabularies/core/>.
+@prefix displayTypes: <http://lblod.data.gift/display-types/>.
+@prefix schema: <http://schema.org/>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/>.
+@prefix mandaat: <http://data.vlaanderen.be/ns/mandaat#>.
+@prefix org: <http://www.w3.org/ns/org#>.
+@prefix extlmb: <http://mu.semte.ch/vocabularies/ext/lmb/>.
+
+ext:persoonF
+    a form:Field;
+    form:displayType displayTypes:personSelector;
+    sh:group ext:mandatarisPG;
+    sh:name "Persoon";
+    sh:order 2;
+    sh:path mandaat:isBestuurlijkeAliasVan.
+ext:mandaatF
+    a form:Field;
+    form:displayType displayTypes:mandatarisMandaatSelector;
+    sh:group ext:mandatarisPG;
+    sh:name "Mandaat";
+    sh:order 3;
+    sh:path org:holds.
+ext:mandatarisStatusCodeF
+    a form:Field;
+    form:displayType displayTypes:mandatarisStatusCodeSelector;
+    sh:group ext:mandatarisPG;
+    sh:name "Status";
+    sh:order 4;
+    sh:path mandaat:status;
+    form:options """{"conceptScheme":"http://data.vlaanderen.be/id/conceptscheme/MandatarisStatusCode","searchEnabled":true}""";
+    form:validatedBy 
+        [
+            a form:RequiredConstraint;
+            form:grouping form:Bag;
+            sh:path mandaat:status;
+            sh:resultMessage "Status is verplicht."
+    ].
+ext:rangordeF
+    a form:Field;
+    form:displayType displayTypes:mandatarisRangorde;
+    sh:group ext:mandatarisPG;
+    sh:name "Rangorde";
+    sh:order 6;
+    sh:path mandaat:rangorde;
+    form:validatedBy [
+      a ext:ValidRangorde;
+      form:grouping form:MatchSome;
+      sh:severity sh:Warning;
+      sh:resultMessage "Er werd geen geldige rangorde herkend";
+      sh:path mandaat:rangorde
+    ].
+ext:startF
+    a form:Field;
+    form:displayType displayTypes:dateTime;
+    sh:group ext:mandatarisPG;
+    sh:name "Start";
+    sh:order 7;
+    sh:path mandaat:start;
+    form:validatedBy 
+        [
+            a form:RequiredConstraint;
+            form:grouping form:Bag;
+            sh:path mandaat:start;
+            sh:resultMessage "Startdatum is verplicht."
+    ].
+ext:eindeF
+    a form:Field;
+    form:displayType displayTypes:dateTime;
+    sh:group ext:mandatarisPG;
+    sh:name "Einde";
+    sh:order 8;
+    sh:path mandaat:einde.
+ext:fractieF
+    a form:Field;
+    form:displayType displayTypes:mandatarisFractieSelector;
+    sh:group ext:mandatarisPG;
+    sh:name "Fractie";
+    sh:order 9;
+    sh:path ( org:hasMembership org:organisation );
+    form:validatedBy 
+        [
+            a form:RequiredConstraint;
+            form:grouping form:Bag;
+            sh:path ( org:hasMembership org:organisation );
+            sh:resultMessage "Dit veld is verplicht."
+    ].
+ext:beleidsdomeinCodeF
+    a form:Field;
+    form:displayType displayTypes:mandatarisBeleidsdomein;
+    ext:extendsGroup ext:mandatarisPG;
+    sh:name "Beleidsdomein";
+    sh:order 10;
+    sh:path mandaat:beleidsdomein;
+    form:options """{"conceptScheme":"http://data.vlaanderen.be/id/conceptscheme/BeleidsdomeinCode","searchEnabled":true, "type":"beleidsdomein-code"}""".
+ext:mandatarisPG
+    a form:PropertyGroup; sh:name ""; sh:order 1.
+
+ext:hiddenPublicationStatusF
+    a form:Field;
+    sh:name "Publication status [hidden input]";
+    sh:order 5001;
+    sh:path extlmb:hasPublicationStatus.
+
+<http://data.lblod.info/id/lmb/forms/mandataris-new>
+    a form:Form, form:TopLevelForm;
+    form:includes
+        ext:persoonF,
+        ext:mandaatF,
+        ext:mandatarisStatusCodeF,
+        ext:rangordeF,
+        ext:startF,
+        ext:eindeF,
+        ext:fractieF,
+        ext:beleidsdomeinCodeF,
+        ext:hiddenPublicationStatusF;
+    sh:group ext:mandatarisPG;
+    form:initGenerator ext:mandatarisG;
+    form:targetType mandaat:Mandataris;
+    form:targetLabel mu:uuid;
+    ext:prefix <http://data.lblod.info/id/mandatarissen/>;
+    ext:withHistory false;
+    mu:uuid "2522a2e2-5242-4b6d-98ee-c5bd709fceaa".
+
+ext:mandatarisG a form:Generator;
+  form:prototype [
+    form:shape [
+      a mandaat:Mandataris;
+      org:hasMembership [
+        a org:Membership
+      ]
+    ]
+  ];
+  form:dataGenerator form:addMuUuid.

--- a/config/form-content/mandataris-ext/form.ttl
+++ b/config/form-content/mandataris-ext/form.ttl
@@ -92,7 +92,7 @@ ext:fractieF
 ext:beleidsdomeinCodeF
     a form:Field;
     form:displayType displayTypes:mandatarisBeleidsdomein;
-    ext:extendsGroup ext:mandatarisPG;
+    sh:group ext:mandatarisPG;
     sh:name "Beleidsdomein";
     sh:order 10;
     sh:path mandaat:beleidsdomein;
@@ -106,7 +106,7 @@ ext:hiddenPublicationStatusF
     sh:order 5001;
     sh:path extlmb:hasPublicationStatus.
 
-<http://data.lblod.info/id/lmb/forms/mandataris-new>
+<http://data.lblod.info/id/lmb/forms/mandataris-ext>
     a form:Form, form:TopLevelForm;
     form:includes
         ext:persoonF,
@@ -124,7 +124,7 @@ ext:hiddenPublicationStatusF
     form:targetLabel mu:uuid;
     ext:prefix <http://data.lblod.info/id/mandatarissen/>;
     ext:withHistory false;
-    mu:uuid "2522a2e2-5242-4b6d-98ee-c5bd709fceaa".
+    mu:uuid "ee79d356-120b-48ca-a7f4-554cfa167518".
 
 ext:mandatarisG a form:Generator;
   form:prototype [


### PR DESCRIPTION
## Description
Add new form which adds beleidsdomeinen to the mandataris new form. These are only showed for the right mandates, due to the beleidsdomeinen custom component. This is not done as an extension as there are some issues with the relative path or with the generator when extending forms.

## How to test
Restart form-content service and check if the form is indeed in the forms route. If you try to create a new form entity with this form, you won't see the beleidsdomeinen, as the mandate selector does not really work in this route (no selected bestuursorgaan). You can see the beleidsdomeinen field in the form if you try to edit a mandataris which already has a mandate schepen or burgemeester. Or you can just try to test this with the installatievergadering redesign, which uses this form.

## Link to other PR's
- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/264
- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/175