### PR TITLE
LMB-553 |Make mandaat, person and selector required

### DIFF
--- a/config/form-content/mandataris-edit/form.ttl
+++ b/config/form-content/mandataris-edit/form.ttl
@@ -16,7 +16,14 @@ ext:mandaatF
     sh:group ext:editMandatarisPG;
     sh:name "Mandaat";
     sh:order 200;
-    sh:path org:holds.
+    sh:path org:holds;
+    form:validatedBy 
+        [
+            a form:RequiredConstraint;
+            form:grouping form:Bag;
+            sh:path org:holds;
+            sh:resultMessage "Mandaat is verplicht."
+    ].
 ext:mandatarisStatusCodeF
     a form:Field;
     form:displayType displayTypes:mandatarisStatusCodeSelector;

--- a/config/form-content/mandataris-ext/form.ttl
+++ b/config/form-content/mandataris-ext/form.ttl
@@ -17,14 +17,28 @@ ext:persoonF
     sh:group ext:mandatarisPG;
     sh:name "Persoon";
     sh:order 2;
-    sh:path mandaat:isBestuurlijkeAliasVan.
+    sh:path mandaat:isBestuurlijkeAliasVan;
+    form:validatedBy 
+        [
+            a form:RequiredConstraint;
+            form:grouping form:Bag;
+            sh:path mandaat:isBestuurlijkeAliasVan;
+            sh:resultMessage "Persoon is verplicht."
+    ].
 ext:mandaatF
     a form:Field;
     form:displayType displayTypes:mandatarisMandaatSelector;
     sh:group ext:mandatarisPG;
     sh:name "Mandaat";
     sh:order 3;
-    sh:path org:holds.
+    sh:path org:holds;
+    form:validatedBy 
+        [
+            a form:RequiredConstraint;
+            form:grouping form:Bag;
+            sh:path org:holds;
+            sh:resultMessage "Mandaat is verplicht."
+    ].
 ext:mandatarisStatusCodeF
     a form:Field;
     form:displayType displayTypes:mandatarisStatusCodeSelector;

--- a/config/form-content/mandataris-new/form.ttl
+++ b/config/form-content/mandataris-new/form.ttl
@@ -17,14 +17,28 @@ ext:persoonF
     sh:group ext:mandatarisPG;
     sh:name "Persoon";
     sh:order 2;
-    sh:path mandaat:isBestuurlijkeAliasVan.
+    sh:path mandaat:isBestuurlijkeAliasVan;
+    form:validatedBy 
+        [
+            a form:RequiredConstraint;
+            form:grouping form:Bag;
+            sh:path mandaat:isBestuurlijkeAliasVan;
+            sh:resultMessage "Persoon is verplicht."
+    ].
 ext:mandaatF
     a form:Field;
     form:displayType displayTypes:mandatarisMandaatSelector;
     sh:group ext:mandatarisPG;
     sh:name "Mandaat";
     sh:order 3;
-    sh:path org:holds.
+    sh:path org:holds;
+    form:validatedBy 
+        [
+            a form:RequiredConstraint;
+            form:grouping form:Bag;
+            sh:path org:holds;
+            sh:resultMessage "Mandaat is verplicht."
+    ].
 ext:mandatarisStatusCodeF
     a form:Field;
     form:displayType displayTypes:mandatarisStatusCodeSelector;


### PR DESCRIPTION
## Description

Mandaat and person should always be required. We are adding this configuration to the ttl forms.

## How to test

Checkout this PR and connect with the PR in the frontend. Try creating or updating a mandataris without a person, fractie or mandaat. (Or all of them as seen in the picture in frontend PR)

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/274
