### PR TITLE
fix tmp bestuursorganen migration

### DIFF
--- a/config/migrations/local/20240701091059-tmp-bestuursorganen.sparql
+++ b/config/migrations/local/20240701091059-tmp-bestuursorganen.sparql
@@ -63,8 +63,7 @@ INSERT {
   GRAPH ?g {
     ?oldMandaat org:role ?role.
   }
-    ?role skos:prefLabel ?mandaatLabel.
 
-    BIND(SHA256(CONCAT("f2373ae0-661f-45b8-8bd3-42b33e10c1a2", ":2025-01-01:", STR(?mandaatLabel), STR(?bestuursorgaanLabel))) AS ?uuid) .
-    BIND(IRI(CONCAT("http://data.lblod.info/id/mandaten/", STR(?uuid))) AS ?mandaat) .
+  BIND(SHA256(CONCAT("f2373ae0-661f-45b8-8bd3-42b33e10c1a2", ":2025-01-01:", STR(?oldMandaat))) AS ?uuid) .
+  BIND(IRI(CONCAT("http://data.lblod.info/id/mandaten/", STR(?uuid))) AS ?mandaat) .
 }


### PR DESCRIPTION
## Description

The burgemeester mandaat for bestuursperiode 2025-heden got split into two different mandates for burgemeester and college burgemeester and schepenen. This PR solves this.

## How to test

Unfortunately this is an update of a existing migration, which means you should clear your existing database.
