### PR TITLE
Owen/rekenhof

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -324,6 +324,14 @@ defmodule Dispatcher do
   end
 
   #################################################################
+  # Rekenhof api
+  #################################################################
+
+  match "/rekenhof-api/*path", %{layer: :api_services, accept: %{any: true}} do
+    forward(conn, path, "http://rekenhof-service/")
+  end
+
+  #################################################################
   # LDES
   #################################################################
   get "/streams/ldes/abb/*path" do

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -225,3 +225,14 @@ services:
       - ./config/sparql-authorization-wrapper:/config
     restart: always
     logging: *default-logging
+
+  rekenhof-service:
+    image: semtech/mu-javascript-template
+    ports:
+      - "1234:80"
+    environment:
+      NODE_ENV: "development"
+    links: 
+      - virtuoso:database
+    volumes:
+      - ./rekenhof-service/:/app/

--- a/rekenhof-service/app.js
+++ b/rekenhof-service/app.js
@@ -1,0 +1,71 @@
+import { app, query } from 'mu';
+import cors from 'cors';
+
+// allowing all origins for now
+app.use(cors());
+
+app.get('/hello', function(req, res) {
+  res.send('Hello from rekenhof-api');
+});
+
+app.get('/bestuurseenheid-data', async function(req, res) {
+  
+  console.log("received request");
+  console.log(req.query);
+  
+  const bestuurseenheid = req.query.bestuurseenheid;
+
+  if (!bestuurseenheid) {
+    return res.status(400).send('Missing bestuurseenheid parameter');
+  }
+
+  const sparqlQuery = `
+    PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+    PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+    PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
+    PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+    PREFIX org: <http://www.w3.org/ns/org#>
+    PREFIX adms: <http://www.w3.org/ns/adms#>
+    PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+    SELECT DISTINCT ?voornaam ?achternaam ?geboortedatum ?geslacht ?rrn ?bestuursorgaanTijdsspecialisatieLabel ?statusLabel ?startdatum ?einddatum ?mandataris ?person ?identifier ?holds_mandaat ?rol ?bestuursorgaanTijdsspecialisatie ?bestuursorgaanPermanent ?PubliekeOrganisatie WHERE {
+
+        ?mandataris a mandaat:Mandataris .
+        ?mandataris mandaat:isBestuurlijkeAliasVan ?person .
+        ?mandataris mandaat:start ?startdatum .
+        ?mandataris mandaat:status ?status .
+
+        ?mandataris org:holds ?holds_mandaat .
+        ?holds_mandaat org:role ?rol . 
+
+        ?bestuursorgaanTijdsspecialisatie org:hasPost ?holds_mandaat . 
+        ?bestuursorgaanTijdsspecialisatie mandaat:isTijdspecialisatieVan ?bestuursorgaanPermanent .
+        ?bestuursorgaanPermanent skos:prefLabel ?bestuursorgaanTijdsspecialisatieLabel .
+        ?bestuursorgaanPermanent besluit:bestuurt ?PubliekeOrganisatie .
+        
+        OPTIONAL { ?person persoon:gebruikteVoornaam ?voornaam . }
+        OPTIONAL { ?person foaf:familyName ?achternaam . }
+        OPTIONAL { ?status skos:prefLabel ?statusLabel . }
+        OPTIONAL { ?person persoon:heeftGeboorte/persoon:datum ?geboortedatum . }
+        OPTIONAL { ?person persoon:geslacht ?geslacht . }
+        OPTIONAL { ?mandataris mandaat:einde ?einddatum . }
+
+        OPTIONAL { ?person adms:identifier ?identifier . 
+                  OPTIONAL { ?identifier skos:notation ?rrn . }
+        }
+      FILTER (?PubliekeOrganisatie = <${bestuurseenheid}>)
+    } LIMIT 1000
+  `;
+
+  const queryUrl = 'http://localhost:8890/sparql'; 
+  const fullUrl = `${queryUrl}?query=${encodeURIComponent(sparqlQuery)}`;
+
+  try {
+    const response = await query(sparqlQuery);
+    res.json(response); 
+  } catch (error) {
+    console.error('Error:', error);
+    res.status(500).send('An error occurred while fetching SPARQL query.');
+  }
+});
+

--- a/rekenhof-service/package.json
+++ b/rekenhof-service/package.json
@@ -1,0 +1,7 @@
+{
+    "dependencies": {
+        "node-fetch": "^3.3.2",
+        "cors": "^2.8.5"
+
+    }
+}


### PR DESCRIPTION
## Description

Adds a docker container that runs a simple microservice that runs a sparql query directly on the virtuoso endpoint which fetches relevant data for the rekenhof with bestuurseenheid URI as parameter.

## How to test

Also run the owen/rekenhof branch of the frontend and then navigate to /rekenhof in the frontend after logging in as a bestuurseenheid.

## Links to other PR's

https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/301