### PR TITLE
LMB-552 | Add inverse relation from person to verkiezingsresultaat

### DIFF
--- a/config/form-content/mandataris-edit/form.ttl
+++ b/config/form-content/mandataris-edit/form.ttl
@@ -15,7 +15,7 @@ ext:mandaatF
     form:displayType displayTypes:mandatarisMandaatSelector;
     sh:group ext:editMandatarisPG;
     sh:name "Mandaat";
-    sh:order 1;
+    sh:order 100;
     sh:path org:holds;
     form:validatedBy
         [

--- a/config/form-content/mandataris-edit/form.ttl
+++ b/config/form-content/mandataris-edit/form.ttl
@@ -15,7 +15,7 @@ ext:mandaatF
     form:displayType displayTypes:mandatarisMandaatSelector;
     sh:group ext:editMandatarisPG;
     sh:name "Mandaat";
-    sh:order 200;
+    sh:order 1;
     sh:path org:holds;
     form:validatedBy
         [

--- a/config/form-content/mandataris-new/form.ttl
+++ b/config/form-content/mandataris-new/form.ttl
@@ -11,9 +11,9 @@ ext:persoonF
     form:displayType displayTypes:personSelector;
     ext:extendsGroup ext:editMandatarisPG;
     sh:name "Persoon";
-    sh:order 2;
+    sh:order 200;
     sh:path mandaat:isBestuurlijkeAliasVan;
-    form:validatedBy 
+    form:validatedBy
         [
             a form:RequiredConstraint;
             form:grouping form:Bag;

--- a/config/form-content/mandataris-new/form.ttl
+++ b/config/form-content/mandataris-new/form.ttl
@@ -11,7 +11,7 @@ ext:persoonF
     form:displayType displayTypes:personSelector;
     ext:extendsGroup ext:editMandatarisPG;
     sh:name "Persoon";
-    sh:order 1;
+    sh:order 2;
     sh:path mandaat:isBestuurlijkeAliasVan;
     form:validatedBy 
         [

--- a/config/resources/external-mandaat.lisp
+++ b/config/resources/external-mandaat.lisp
@@ -146,7 +146,10 @@
               (nationality :via ,(s-prefix "persoon:heeftNationaliteit")
                             :as "nationalities")
               (fractie :via ,(s-prefix "extlmb:currentFracties")
-                            :as "current-fracties"))
+                            :as "current-fracties")
+              (verkiezingsresultaat :via ,(s-prefix "mandaat:isResultaatVan")
+                            :inverse t
+                            :as "verkiezingsresultaten"))
   :has-one `((geboorte :via ,(s-prefix "persoon:heeftGeboorte")
                        :as "geboorte")
              (identificator :via ,(s-prefix "adms:identifier")


### PR DESCRIPTION
## Description

Extend the person domain with an inverse relation to verkiezingsresultaat and change the orde rof persoon and mandaat field. You should alwyas first select a mandaat before you can select a person.

## How to test

Togheter with the frontend.

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/305
