### PR TITLE
LMB-683 |Add besluiten & artikels to ldes

### DIFF
--- a/config/ldes-delta-pusher/dispatch.ts
+++ b/config/ldes-delta-pusher/dispatch.ts
@@ -1,12 +1,14 @@
 import { Changeset } from "../types";
 import { handleRegularTypes } from "./handle-regular-types";
 import { handleMandatarisType } from "./handle-mandataris-type";
+import { handleDecisionType } from "./handle-decision-type";
 
 export default async function dispatch(changesets: Changeset[]) {
   const nonHistoryChangesets = filterOutHistoryChanges(changesets);
 
   handleRegularTypes(nonHistoryChangesets);
   handleMandatarisType(nonHistoryChangesets);
+  handleDecisionType(nonHistoryChangesets);
 }
 
 function filterOutHistoryChanges(changesets: Changeset[]) {

--- a/config/ldes-delta-pusher/handle-decision-type.ts
+++ b/config/ldes-delta-pusher/handle-decision-type.ts
@@ -1,9 +1,38 @@
+import { query } from "mu";
 import { Changeset } from "../types";
+
 import { publishInterestingSubjects } from "./handle-types-util";
 import { InterestingSubject } from "./publisher"
 
-const interestingSubjects = async (): Promise<InterestingSubject[]> => {
-  return [];
+const regularTypesToLDESMapping = {
+  "http://data.vlaanderen.be/ns/besluit#Artikel": "public",
+  "http://data.vlaanderen.be/ns/besluit#Besluit": "public",
+}
+
+const interestingSubjects = async (subjects: string[]): Promise<InterestingSubject[]> => {
+  const types = Object.keys(regularTypesToLDESMapping);
+  const matches = await query(`
+    PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+
+    SELECT DISTINCT ?s ?type
+    WHERE {
+      ?s a ?type .
+      VALUES ?type { ${types.map((type) => `<${type}>`).join(" ")} }
+      VALUES ?s { ${[...subjects].map((subject) => `<${subject}>`).join(" ")} }
+
+      ?s ?predicate ?mandataris.
+      FILTER ( ?predicate = mandaat:bekrachtigtAanstellingVan || ?predicate = mandaat:bekrachtigtOntslagVan )
+    }
+  `);
+  return matches.results.bindings
+    .map((binding) => {
+      const ldesType = regularTypesToLDESMapping[binding.type.value];
+      if (!ldesType) {
+        return null;
+      }
+      return { uri: binding.s.value, ldesType, type: binding.type.value };
+    })
+    .filter((b) => !!b);
 }
 
 export const handleDecisionType = async (changesets: Changeset[]) => {

--- a/config/ldes-delta-pusher/handle-decision-type.ts
+++ b/config/ldes-delta-pusher/handle-decision-type.ts
@@ -1,0 +1,11 @@
+import { Changeset } from "../types";
+import { publishInterestingSubjects } from "./handle-types-util";
+import { InterestingSubject } from "./publisher"
+
+const interestingSubjects = async (): Promise<InterestingSubject[]> => {
+  return [];
+}
+
+export const handleDecisionType = async (changesets: Changeset[]) => {
+  await publishInterestingSubjects(changesets, interestingSubjects);
+};


### PR DESCRIPTION
## Description

Add the besluiten and or artikels to the LDES stream when it has predicate _mandaat:bekrachtigtAanstellingVan_ of _mandaat:bekrachtigtOntslagVan_

## How to test

Create a besluit and artikel without a predicate jsut the besluit or artikel type and two with a predicate
https://github.com/lblod/app-lokaal-mandatenbeheer/pull/192#issuecomment-2309813050
