### PR TITLE
can't remove this link because we need it for checking if people are elected during the current period

### DIFF
--- a/config/migrations/local/20240702103846-move-tmp-verkiezingsdata.sparql
+++ b/config/migrations/local/20240702103846-move-tmp-verkiezingsdata.sparql
@@ -1,4 +1,4 @@
-prefix mandaat:	<http://data.vlaanderen.be/ns/mandaat#> 
+prefix mandaat:	<http://data.vlaanderen.be/ns/mandaat#>
 prefix bestuursorgaan: <http://data.lblod.info/id/bestuursorganen/>
 prefix verkiezingen: <http://data.lblod.info/id/rechtstreekse-verkiezingen/>
 prefix xsd:	<http://www.w3.org/2001/XMLSchema#>
@@ -7,7 +7,6 @@ PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
 
 DELETE {
   GRAPH ?g {
-    ?verkiezing mandaat:steltSamen ?oldBestuursorgaanInDeTijd .
     ?verkiezing mandaat:datum ?datum .
   }
 }


### PR DESCRIPTION

## Description

We need this link because if we add a person during the current period for e.g. gemeenteraad, they need to have been elected during the election that mandaat:steltSamen this bestuursorgaan.

## How to test

Since this migration is broken, you need to start over from a new toLoad folder