### PR TITLE
LMB-607 | Update domain with link from mandataris to besluit/artikel

### DIFF
--- a/config/cl-authorization/config.lisp
+++ b/config/cl-authorization/config.lisp
@@ -105,6 +105,8 @@
   ("persoon:Geboorte" -> _)
   ("org:Membership" -> _)
   ("besluit:Besluit" -> _)
+  ("besluit:Artikel" -> _)
+  ("eli:LegalResource" -> _)
   ("besluit:Bestuursorgaan" -> _)
   ("mandaat:Mandataris" -> _)
   ("mandaat:Mandaat" -> _)

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -109,6 +109,15 @@ defmodule Dispatcher do
   #################################################################
   # Mandaat resources
   #################################################################
+  match "/besluiten/*path", %{layer: :resources, accept: %{json: true}} do
+    forward(conn, path, "http://cache/besluiten/")
+  end
+  match "/artikels/*path", %{layer: :resources, accept: %{json: true}} do
+    forward(conn, path, "http://cache/artikels/")
+  end
+  match "/rechtsgronden/*path", %{layer: :resources, accept: %{json: true}} do
+    forward(conn, path, "http://cache/rechtsgronden/")
+  end
   match "/fracties/*path", %{layer: :resources, accept: %{json: true}} do
     forward(conn, path, "http://cache/fracties/")
   end

--- a/config/resources/external-besluit.lisp
+++ b/config/resources/external-besluit.lisp
@@ -3,7 +3,25 @@
 ;; only part of the resources have been imported
 ;; in this file there have also been some additions to some resources.
 
-(define-resource besluit ()
+(define-resource rechtsgrond () 
+  :class (s-prefix "eli:LegalResource")
+  :properties `(
+    (:bekrachtigt-aanstelling-van :string ,(s-prefix "mandaat:bekrachtigtAanstellingVan"))
+    (:bekrachtigt-ontslag-van :string ,(s-prefix "mandaat:bekrachtigtOntslagVan"))
+  )
+  :resource-base (s-url "http://data.lblod.info/id/rechtsgronden-abstractie/")
+  :features '(include-uri)
+  :on-path "rechtsgronden"
+)
+
+(define-resource artikel (rechtsgrond)
+  :class (s-prefix "besluit:Artikel")
+  :resource-base (s-url "http://data.lblod.info/id/artikels/")
+  :features '(include-uri)
+  :on-path "artikels"
+)
+
+(define-resource besluit (rechtsgrond)
   :class (s-prefix "besluit:Besluit")
   :properties `((:beschrijving :string ,(s-prefix "eli:description"))
                 (:citeeropschrift :string ,(s-prefix "eli:title_short"))
@@ -13,13 +31,6 @@
                 (:taal :url ,(s-prefix "eli:language"))
                 (:titel :string ,(s-prefix "eli:title"))
                 (:score :float ,(s-prefix "nao:score")))
-  :has-one `((rechtsgrond-besluit :via ,(s-prefix "eli:realizes") ;; This relation resources are not defined in this project
-                                  :as "realisatie")
-             (behandeling-van-agendapunt :via ,(s-prefix "prov:generated") ;; This relation resources are not defined in this project
-                                         :inverse t
-                                         :as "volgend-uit-behandeling-van-agendapunt"))
-  :has-many `((published-resource :via ,(s-prefix "prov:wasDerivedFrom") ;; This relation resources are not defined in this project
-                                  :as "publications"))
   :resource-base (s-url "http://data.lblod.info/id/besluiten/")
   :features '(include-uri)
   :on-path "besluiten")

--- a/config/resources/external-besluit.lisp
+++ b/config/resources/external-besluit.lisp
@@ -9,7 +9,7 @@
     (:bekrachtigt-aanstelling-van :string ,(s-prefix "mandaat:bekrachtigtAanstellingVan"))
     (:bekrachtigt-ontslag-van :string ,(s-prefix "mandaat:bekrachtigtOntslagVan"))
   )
-  :resource-base (s-url "http://data.lblod.info/id/rechtsgronden-abstractie/")
+  :resource-base (s-url "http://data.lblod.info/id/rechtsgronden/")
   :features '(include-uri)
   :on-path "rechtsgronden"
 )

--- a/config/resources/external-mandaat.lisp
+++ b/config/resources/external-mandaat.lisp
@@ -104,7 +104,13 @@
              (mandataris :via ,(s-prefix "owl:sameAs")
                          :as "duplicate-of")
              (mandataris-publication-status-code :via ,(s-prefix "lmb:hasPublicationStatus")
-                         :as "publication-status"))
+                         :as "publication-status")
+             (rechtsgrond :via ,(s-prefix "mandaat:bekrachtigtAanstellingVan")
+                         :inverse t
+                         :as "aanstelling-bekrachtigd-door")
+             (rechtsgrond :via ,(s-prefix "mandaat:bekrachtigtOntslagVan")
+                         :inverse t
+                         :as "ontslag-bekrachtigd-door"))
   :resource-base (s-url "http://data.lblod.info/id/mandatarissen/")
   :features '(include-uri)
   :on-path "mandatarissen")


### PR DESCRIPTION
## Description

Creating an abstract _rechtsgrond_ resource that will hold the _bekrachtigtAanstellingVan_ & _bekrachtigtOntslagVan_. Added an inverse relation for both properties of rechtsgrond on mandataris.

## How to test

Create a besluit and link a mandataris to the besluit. The mandataris should hold the besluit.

```sparql
PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
PREFIX mu: <http://mu.semte.ch/vocabularies/core/>

INSERT DATA {
GRAPH <http://mu.semte.ch/graph/organizations/974816591f269bb7d74aa1720922651529f3d3b2a787f5c60b73e5a0384950a4/LoketLB-mandaatGebruiker> {
 <http://decision-5> a besluit:Besluit;
     mu:uuid """fc7cacae-c2b6-465f-8005-c009e82b4d33""";
     mandaat:bekrachtigtAanstellingVan <http://data.lblod.info/id/mandatarissen/600A921F291D6E0008000046>.
}}
```

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/311
- https://github.com/lblod/mandataris-service/pull/41
