### PR TITLE
faster initial dump of ldes stream, paginated, also fix some things regarding persons being public

### DIFF
--- a/config/ldes-delta-pusher/handle-regular-types.ts
+++ b/config/ldes-delta-pusher/handle-regular-types.ts
@@ -1,18 +1,24 @@
 import { Changeset } from "../types";
 import { query } from "mu";
-import {
-  InterestingSubject,
-  publishInterestingSubjects,
-} from "./handle-types-util";
+import { publishInterestingSubjects } from "./handle-types-util";
+import { InterestingSubject, LDES_TYPE, TypesWithFilter } from "./publisher";
 
-const regularTypesToLDESMapping = {
+const regularTypesToLDESMapping: {
+  [key: string]: LDES_TYPE | TypesWithFilter;
+} = {
   "http://data.vlaanderen.be/ns/mandaat#Fractie": "public",
   "http://www.w3.org/ns/org#Membership": "public",
   "http://data.vlaanderen.be/ns/mandaat#Mandaat": "public",
-  "http://www.w3.org/ns/person#Person": "public",
+  "http://www.w3.org/ns/person#Person": {
+    public: {
+      filter: `FILTER(?p NOT IN (<http://data.vlaanderen.be/ns/persoon#heeftGeboorte>, <http://www.w3.org/ns/adms#identifier>, <http://data.vlaanderen.be/ns/persoon#geslacht>))`,
+    },
+    abb: {},
+    internal: {},
+  },
   "http://purl.org/dc/terms/PeriodOfTime": "public",
   "http://www.w3.org/ns/adms#Identifier": "abb",
-  "http://data.vlaanderen.be/ns/persoon#Geboorte": "public",
+  "http://data.vlaanderen.be/ns/persoon#Geboorte": "abb",
   "http://schema.org/ContactPoint": "abb",
   "http://www.w3.org/ns/locn#Address": "abb",
 };

--- a/config/ldes-delta-pusher/handle-types-util.ts
+++ b/config/ldes-delta-pusher/handle-types-util.ts
@@ -1,6 +1,5 @@
 import { Changeset } from "../types";
-import { query } from "mu";
-import { InterestingSubject, LDES_TYPE, publish } from "./publisher";
+import { InterestingSubject, publish } from "./publisher";
 import { log } from "./logger";
 
 type SubjectFilter = (subjects: string[]) => Promise<InterestingSubject[]>;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,9 +185,19 @@ services:
   # LDES
   ##############################################################################
   ldes-delta-pusher:
-    image: redpencil/ldes-delta-pusher:0.2.0
+    image: redpencil/ldes-delta-pusher:0.3.0
     environment:
       LDES_ENDPOINT: "http://ldes-backend"
+      LDES_BASE: "http://lmb.lblod.info/streams/ldes"
+      MAX_PAGE_SIZE_BYTES: 10000000
+      INITIAL_STATE_LIMIT: 10000
+      # for catching up after restart
+      #LDES_STATUS_GRAPH: "http://mu.semte.ch/graphs/ldes-status"
+      DIRECT_DB_ENDPOINT: "http://virtuoso:8890/sparql"
+      WRITE_INITIAL_STATE: "false"
+      # for writing initial state
+      #WRITE_INITIAL_STATE: "true"
+
     volumes:
       - ./config/ldes-delta-pusher/:/config/
     restart: always


### PR DESCRIPTION
## Description

faster initial dump of ldes stream, paginated, also fix some things regarding persons being public

This requires the version of the ldes stream from the linked PR


## How to test

Delete the contents of your data/ldes-stream folder (but keep the folder)
Toggle the WRITE_INITIAL_STATE variable to true 
start the ldes-delta-pusher service to write the initial state
inspect the resulting files

upload the resulting files to a graph of your choice and run a query to verify that all instances of the target type are present e.g.:

```
  PREFIX person: <http://www.w3.org/ns/person#>
  PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
  SELECT * WHERE {
    GRAPH ?g {
      ?s a mandaat:Mandataris.
      FILTER NOT EXISTS {
        GRAPH <http://localhost/temp/ldes/public> {
          ?member dcterms:isVersionOf ?s.
        }
      }
    }
FILTER (?g != <http://localhost/temp/ldes/public>)
} limit 10
```

## Links to other PR's

- https://github.com/redpencilio/ldes-delta-pusher-service/pull/6