### PR TITLE
LMB-587 add migration to remove duplicate skos reflabels bestuursorganen

### DIFF
--- a/config/migrations/local/20240829152518-remove-duplicate-bestuursorgaan-names.sparql
+++ b/config/migrations/local/20240829152518-remove-duplicate-bestuursorgaan-names.sparql
@@ -20,5 +20,6 @@ WHERE {
   ?bestuursorgaan skos:prefLabel ?label1 ;
     skos:prefLabel ?label2 .
   FILTER (?label1 != ?label2)
+  # You need to configure here which label you want to keep, these two cases cover our current database.
   FILTER ((STRENDS(?label1, "-edit")) || STRENDS(?label2, "(voor fusie)"))
 }

--- a/config/migrations/local/20240829152518-remove-duplicate-bestuursorgaan-names.sparql
+++ b/config/migrations/local/20240829152518-remove-duplicate-bestuursorgaan-names.sparql
@@ -1,0 +1,24 @@
+ PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+ PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+DELETE {
+  GRAPH ?g {
+    ?bestuursorgaan skos:prefLabel ?label1.
+  }
+}
+WHERE {
+  {
+    SELECT ?g ?bestuursorgaan WHERE {
+      GRAPH ?g {
+        ?bestuursorgaan a besluit:Bestuursorgaan ;
+          skos:prefLabel ?o .
+      }
+    }
+    GROUP BY ?g ?bestuursorgaan
+    HAVING (COUNT(?o) > 1)
+  }
+  ?bestuursorgaan skos:prefLabel ?label1 ;
+    skos:prefLabel ?label2 .
+  FILTER (?label1 != ?label2)
+  FILTER ((STRENDS(?label1, "-edit")) || STRENDS(?label2, "(voor fusie)"))
+}


### PR DESCRIPTION
## Description

Removes duplicate skos preflabels of bestuursorganen.
It is configured manually which preflabel needs to be removed, now we just remove the ones that end with "-edit" or don't have "(voor fusie)", this covers all values in the test data, might need to change later on.

## How to test

You can use the following query to find bestuursorganen that have duplicate skos:prefLabels
```
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>

SELECT ?bestuursorgaan ?label1 ?label2 WHERE {
  {
    SELECT ?bestuursorgaan WHERE {
      GRAPH ?g {
        ?bestuursorgaan a besluit:Bestuursorgaan ;
          skos:prefLabel ?o .
      }
    }
    GROUP BY ?g ?bestuursorgaan
    HAVING (COUNT(?o) > 1)
  }
  ?bestuursorgaan skos:prefLabel ?label1 ;
    skos:prefLabel ?label2 .
  FILTER (?label1 != ?label2)
  FILTER ((STRENDS(?label1, "-edit")) || STRENDS(?label2, "(voor fusie)"))
}
```

If you go there before running your migrations you'll see duplicate bestuursorganen. If you run your migrations and return to the page or select another one, you'll see the duplicates are gone.

If you return to the same page, be sure your cache restarts.