### PR TITLE
track the bestuurseenheid when publishing on ldes

### DIFF
--- a/config/ldes-delta-pusher/initialization.ts
+++ b/config/ldes-delta-pusher/initialization.ts
@@ -1,0 +1,78 @@
+const regularTypes = {
+  "http://data.vlaanderen.be/ns/mandaat#Fractie": "public",
+  "http://www.w3.org/ns/org#Membership": "public",
+  "http://data.vlaanderen.be/ns/mandaat#Mandaat": "public",
+  "http://purl.org/dc/terms/PeriodOfTime": "public",
+  "http://www.w3.org/ns/adms#Identifier": "abb",
+  "http://data.vlaanderen.be/ns/persoon#Geboorte": "abb",
+};
+
+// this is so we can relate our instances to the bestuurseenheid they concern
+const extraConstruct = `
+  ?versionedS <http://mu.semte.ch/vocabularies/ext/relatedTo> ?bestuurseenheid.
+`;
+const extraWhere = `
+  GRAPH ?g {
+    ?s a ?thing.
+  }
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?g <http://mu.semte.ch/vocabularies/ext/ownedBy> ?bestuurseenheid.
+  }
+`;
+
+export const initialization = {
+  public: {
+    "http://data.vlaanderen.be/ns/mandaat#Mandataris": {
+      filter: `
+        OPTIONAL { ?s <http://mu.semte.ch/vocabularies/ext/lmb/hasPublicationStatus> ?publicationStatus. }
+        FILTER(!BOUND(?publicationStatus) || ?publicationStatus != <http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/588ce330-4abb-4448-9776-a17d9305df07>)`,
+      extraConstruct,
+      extraWhere,
+    },
+    "http://www.w3.org/ns/person#Person": {
+      filter: `FILTER(?p NOT IN (<http://data.vlaanderen.be/ns/persoon#heeftGeboorte>, <http://www.w3.org/ns/adms#identifier>, <http://data.vlaanderen.be/ns/persoon#geslacht>))
+      `,
+      extraConstruct,
+      extraWhere,
+    },
+  },
+  abb: {
+    // meaning there is no filter
+    "http://data.vlaanderen.be/ns/mandaat#Mandataris": {
+      extraConstruct,
+      extraWhere,
+    },
+    "http://www.w3.org/ns/person#Person": {
+      extraConstruct,
+      extraWhere,
+    },
+  },
+  internal: {
+    "http://data.vlaanderen.be/ns/mandaat#Mandataris": {
+      extraConstruct,
+      extraWhere,
+    },
+    "http://www.w3.org/ns/person#Person": {
+      extraConstruct,
+      extraWhere,
+    },
+  },
+};
+
+Object.keys(regularTypes).forEach((type) => {
+  const level = regularTypes[type];
+  const defaultConfig = {
+    extraConstruct,
+    extraWhere,
+  };
+  if (level === "public") {
+    initialization.public[type] = defaultConfig;
+    initialization.abb[type] = defaultConfig;
+    initialization.internal[type] = defaultConfig;
+  } else if (level === "abb") {
+    initialization.abb[type] = defaultConfig;
+    initialization.internal[type] = defaultConfig;
+  } else if (level === "internal") {
+    initialization.internal[type] = defaultConfig;
+  }
+});

--- a/config/ldes-delta-pusher/publisher.ts
+++ b/config/ldes-delta-pusher/publisher.ts
@@ -42,8 +42,8 @@ const fetchSubjectData = async (
       GRAPH ?g {
         <${subject.uri}> ?p ?o .
         ?org a <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan>.
-        ?org <http://data.vlaanderen.be/ns/besluit#bestuurt> ?bestuurseenheid .
       }
+      ?g ext:ownedBy ?bestuurseenheid .
       ${predicateLimiter}
       ${filter}
       FILTER NOT EXISTS {

--- a/config/ldes-delta-pusher/publisher.ts
+++ b/config/ldes-delta-pusher/publisher.ts
@@ -29,14 +29,20 @@ const fetchSubjectData = async (
       ${properties.map((p) => sparqlEscapeUri(p)).join("\n")}
     }`;
   }
+
   const filter =
     typeof subject.ldesType === "object" ? subject.ldesType[target].filter : "";
+  // we are also publishing the bestuuseenheid with our data so consuming apps easily know where to put the concept
   const data = await query(`
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     CONSTRUCT {
       <${subject.uri}> ?p ?o .
+      <${subject.uri}> ext:relatedTo ?bestuurseenheid .
     } WHERE {
       GRAPH ?g {
         <${subject.uri}> ?p ?o .
+        ?org a <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan>.
+        ?org <http://data.vlaanderen.be/ns/besluit#bestuurt> ?bestuurseenheid .
       }
       ${predicateLimiter}
       ${filter}

--- a/config/migrations/2024/20240905101700-mark-bestuurseenheid-graphs.sparql
+++ b/config/migrations/2024/20240905101700-mark-bestuurseenheid-graphs.sparql
@@ -1,0 +1,10 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?g <http://mu.semte.ch/vocabularies/ext/ownedBy> ?bestuurseenheid.
+  }
+} WHERE {
+  GRAPH ?g {
+    ?org besluit:bestuurt ?bestuurseenheid.
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -180,7 +180,7 @@ services:
   # LDES
   ##############################################################################
   ldes-delta-pusher:
-    image: redpencil/ldes-delta-pusher:0.3.0
+    image: redpencil/ldes-delta-pusher:0.4.0
     environment:
       LDES_ENDPOINT: "http://ldes-backend"
       LDES_BASE: "http://lmb.lblod.info/streams/ldes"


### PR DESCRIPTION
## Description

When publishing deltas to the ldes feed, we should also publish the bestuurseenheid that is linked to the concept. This makes it easier for consumers like GN to put the information in the right graph(s).

## How to test

Do an update to different concepts (mandataris, person, ...) and verify that the concept is published with the bestuurseenheid link in the different feeds.

## Linked PRs

This requires extra hooks in the initialization of the ldes feed: https://github.com/redpencilio/ldes-delta-pusher-service/pull/7