### PR TITLE
reinstate deputatie and politieraad

### DIFF
--- a/config/migrations/2024/20240000000002-add-mock-users.sparql
+++ b/config/migrations/2024/20240000000002-add-mock-users.sparql
@@ -37,8 +37,8 @@ WHERE {
      mu:uuid ?id;
      skos:prefLabel ?naam;
      besluit:classificatie/skos:prefLabel ?classificatie.
-     # provincies, gemeentes, ocmws en districten
-     FILTER (?bestuurseenheidscodes IN ( bestuurseenheidscode:5ab0e9b8a3b2ca7c5e000000, bestuurseenheidscode:5ab0e9b8a3b2ca7c5e000001, bestuurseenheidscode:5ab0e9b8a3b2ca7c5e000002, bestuurseenheidscode:5ab0e9b8a3b2ca7c5e000003 ))
+     # provincies, gemeentes, ocmws en districten en Politieraad
+     FILTER (?bestuurseenheidscodes IN ( bestuurseenheidscode:5ab0e9b8a3b2ca7c5e000000, bestuurseenheidscode:5ab0e9b8a3b2ca7c5e000001, bestuurseenheidscode:5ab0e9b8a3b2ca7c5e000002, bestuurseenheidscode:5ab0e9b8a3b2ca7c5e000003, bestuurseenheidscode:a3922c6d-425b-474f-9a02-ffb71a436bfc ))
      BIND(CONCAT(?classificatie, " ", ?naam) as ?volledigeNaam)
      BIND(MD5(?volledigeNaam) as ?uuidPersoon)
      BIND(MD5(CONCAT(?volledigeNaam,"ACCOUNT")) as ?uuidAccount)

--- a/config/migrations/2024/20240910082600-add-politieraad-to-andere.sparql
+++ b/config/migrations/2024/20240910082600-add-politieraad-to-andere.sparql
@@ -1,0 +1,16 @@
+PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX skos:	<http://www.w3.org/2004/02/skos/core#>
+PREFIX rdfs:	<http://www.w3.org/2000/01/rdf-schema#>
+PREFIX mu:   <http://mu.semte.ch/vocabularies/core/>
+PREFIX extlmb:  <http://mu.semte.ch/vocabularies/ext/lmb/>
+PREFIX conceptschemes: <http://lblod.data.gift/concept-schemes/>
+PREFIX bcc:  <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    # andere
+    # bevoegd beslissingsorgaan
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> skos:topConceptOf extlmb:vrije-bestuursorgaan-codes;
+      skos:inScheme extlmb:vrije-bestuursorgaan-codes.
+  }
+}

--- a/scripts/loket-to-lmb-transform/deleteUnwantedInstances.ts
+++ b/scripts/loket-to-lmb-transform/deleteUnwantedInstances.ts
@@ -24,8 +24,10 @@ async function deleteUnwantedBestuursOrgs() {
       <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000008>, # Vast Bureau
       <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000009>, # BCSD
       <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000a>, # Districtsraad
+      <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000d>, # Deputatie
       <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000b>, # Districtscollege
       <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000c>, # Provincieraad
+      <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d>, # Politieraad
       <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/180a2fba-6ca9-4766-9b94-82006bb9c709>, # Gouverneur
       <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/9314533e-891f-4d84-a492-0338af104065> # Districtsburgemeester
 		))


### PR DESCRIPTION
## Description

reinstate deputatie and politieraad

## How to test

log in as vlaams brabant, see the deputatie is still there.

politieraad is still there in the data after the transform but is linked to a bestuurseenheid that we don't support yet. Still we should already add it back in so we can add the bestuurseenheid after