### PR TITLE
LMB-438 | Add migration removing end date and adding new to 2025-01-01

### DIFF
--- a/config/migrations/2024/20240910114100-set-end-date-for-bestuursperiode-2019-2025.sparql
+++ b/config/migrations/2024/20240910114100-set-end-date-for-bestuursperiode-2019-2025.sparql
@@ -1,0 +1,27 @@
+PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+DELETE {
+  GRAPH ?boiGraph {
+    ?bestuursorgaan mandaat:bindingEinde ?einde.
+  }
+}
+INSERT {
+  GRAPH ?boiGraph {
+    ?bestuursorgaan mandaat:bindingEinde "2025-01-01T00:00:00Z"^^xsd:dateTime.
+  }
+}
+WHERE {
+ GRAPH ?publicGraph {
+  ?bestuursperiode a  lmb:Bestuursperiode;
+    lmb:startYear 2019 ;
+    lmb:endYear  2025 .
+ }
+ GRAPH ?boiGraph {
+  ?bestuursorgaan a besluit:Bestuursorgaan;
+    lmb:heeftBestuursperiode ?bestuursperiode;
+    mandaat:bindingEinde ?einde.
+ }
+}


### PR DESCRIPTION
## Description

We want to set the enddate of the current bestuursorganen to 2025-01-01 instead of 2024-12-06

## How to test

This query should give you all bestuursorganen from current bestuursperiode. The ?einde should be set to 2025-01-01
```
PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>

select distinct ?bestuursorgaan ?start ?einde where {
 ?bestuursperiode a  lmb:Bestuursperiode;
       lmb:startYear 2019 ;
      lmb:endYear  2025 .

 ?bestuursorgaan a besluit:Bestuursorgaan;
    lmb:heeftBestuursperiode ?bestuursperiode;
     mandaat:bindingStart ?start;
     mandaat:bindingEinde ?einde.
}
```
![image](https://github.com/user-attachments/assets/e92e0893-b0c0-4d69-b8d6-ebedca0afc8c)
