### PR TITLE
LMB-593: remove property group title for adding bestuursorgaan

### DIFF
--- a/config/form-content/bestuursorgaan/form.ttl
+++ b/config/form-content/bestuursorgaan/form.ttl
@@ -48,7 +48,7 @@ ext:hiddenBestuurseenheidF
     sh:path besluit:bestuurt.
 
 ext:bestuursorgaanPG
-    a form:PropertyGroup; sh:name "Bestuursorgaan"; sh:order 1.
+    a form:PropertyGroup; sh:name ""; sh:order 1.
 
 <http://data.lblod.info/id/lmb/forms/bestuursorgaan>
     a form:Form, form:TopLevelForm;


### PR DESCRIPTION
## Description

Removing the property group title because the modal in the frontend already has a title

## How to test

Press the button add orgaan on the organen overview.

The modal should look like this 
![image](https://github.com/user-attachments/assets/793dc530-749e-453f-bc8d-bcedec9d9173)


