### PR TITLE
 LMB-698 | Make rechtsgrond have properties instead of relation to aanstelling or ontslag

### DIFF
--- a/config/resources/external-besluit.lisp
+++ b/config/resources/external-besluit.lisp
@@ -5,9 +5,9 @@
 
 (define-resource rechtsgrond () 
   :class (s-prefix "eli:LegalResource")
-  :has-one `(
-    (mandataris :via ,(s-prefix "mandaat:bekrachtigtAanstellingVan") :as "bekrachtigt-aanstelling-van")
-    (mandataris :via ,(s-prefix "mandaat:bekrachtigtOntslagVan") :as "bekrachtigt-ontslag-van")
+  :properties `(
+    (:bekrachtigt-aanstelling-van :string ,(s-prefix "mandaat:bekrachtigtAanstellingVan"))
+    (:bekrachtigt-ontslag-van :string ,(s-prefix "mandaat:bekrachtigtOntslagVan"))
   )
   :resource-base (s-url "http://data.lblod.info/id/rechtsgronden/")
   :features '(include-uri)


### PR DESCRIPTION
## Description

As the frontend only wants to set the linktobesluit on the mandataris and not link it directly with the besluit, this commit can be reverted.

## How to test

Follow the frontend

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/327
