### PR TITLE
remove person-uri-for-secial-security-number service

### DIFF
--- a/docker-compose.mac.yml
+++ b/docker-compose.mac.yml
@@ -17,8 +17,6 @@ services:
     platform: linux/amd64
   file:
     platform: linux/amd64
-  person-uri-for-social-security-number:
-    platform: linux/amd64
   login:
     platform: linux/amd64
   form-content:


### PR DESCRIPTION
## Description

Removed the service from `docker-compose.mac.yml`, couldn't really find it any other place (got removed here https://github.com/lblod/app-lokaal-mandatenbeheer/pull/201).

## How to test

Maybe check if you can find any other reference to the service.
