### PR TITLE
Bump versions GS32 - sprint 3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,7 +117,7 @@ services:
     restart: always
     logging: *default-logging
   frontend:
-    image: lblod/frontend-lokaal-mandatenbeheer:0.1.1
+    image: lblod/frontend-lokaal-mandatenbeheer:0.1.2
     labels:
       - "logging=true"
     restart: always
@@ -150,7 +150,7 @@ services:
     volumes:
       - ./config/form-content:/config
   mandataris:
-    image: lblod/mandataris-service:0.0.8
+    image: lblod/mandataris-service:0.0.9
     labels:
       - "logging=true"
     restart: always


### PR DESCRIPTION
## Description
Bump versions frontend and mandataris-service to be able to cutover the database on test.
