### PR TITLE
add missing volume ldes-delta-pusher

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -199,6 +199,7 @@ services:
 
     volumes:
       - ./config/ldes-delta-pusher/:/config/
+      - ./data/ldes-feed/:/data/
     restart: always
     labels:
       - "logging=true"


### PR DESCRIPTION
## Description

A volume seems to be missing to be able to write the initial state, this PR adds this configuration to the docker compose.

## How to test

Without this line the "WRITE_INITIAL_STATE" does not work.
