### PR TITLE
remove local bestuursorgaan instances that were created before

### DIFF
--- a/config/migrations/2024/20241003084700-cleanup-local-bestuursorganen.sparql
+++ b/config/migrations/2024/20241003084700-cleanup-local-bestuursorganen.sparql
@@ -1,0 +1,58 @@
+# had to split this query into several because virtuoso didn't like the number of optionals i used...
+# mandataris
+DELETE {
+  GRAPH ?g {
+    ?mandataris ?manp ?mano.
+  }
+} WHERE {
+  ?orgInT <http://lblod.data.gift/vocabularies/lmb/heeftBestuursperiode> <http://data.lblod.info/id/concept/Bestuursperiode/96efb929-5d83-48fa-bfbb-b98dfb1180c7> .
+  ?orgInT <http://data.vlaanderen.be/ns/mandaat#bindingEinde> ?einde.
+  GRAPH ?g {
+    ?orgInT <http://www.w3.org/ns/org#hasPost> ?mdt.
+    ?mandataris <http://www.w3.org/ns/org#holds> ?mdt.
+    ?mandataris ?manp ?mano.
+  }
+};
+# fractions and memberships
+DELETE {
+  GRAPH ?g {
+    ?fractie ?fp ?fo.
+    ?lidmaatschap ?lp ?lo.
+  }
+} WHERE {
+  ?orgInT <http://lblod.data.gift/vocabularies/lmb/heeftBestuursperiode> <http://data.lblod.info/id/concept/Bestuursperiode/96efb929-5d83-48fa-bfbb-b98dfb1180c7> .
+  ?orgInT <http://data.vlaanderen.be/ns/mandaat#bindingEinde> ?einde.
+  GRAPH ?g {
+    ?fractie <http://www.w3.org/ns/org#memberOf> ?orgInT.
+    ?fractie ?fp ?fo.
+    OPTIONAL {
+      ?lidmaatschap <http://www.w3.org/ns/org#organisation> ?fractie.
+      ?lidmaatschap ?lp ?lo.
+    }
+  }
+};
+# mandates
+DELETE {
+  GRAPH ?g {
+    ?mandaat ?mp ?mo.
+  }
+} WHERE {
+  ?orgInT <http://lblod.data.gift/vocabularies/lmb/heeftBestuursperiode> <http://data.lblod.info/id/concept/Bestuursperiode/96efb929-5d83-48fa-bfbb-b98dfb1180c7> .
+  ?orgInT <http://data.vlaanderen.be/ns/mandaat#bindingEinde> ?einde.
+  GRAPH ?g {
+    ?orgInT <http://www.w3.org/ns/org#hasPost> ?mandaat.
+    ?mandaat ?mp ?mo.
+  }
+};
+# org itself
+DELETE {
+  GRAPH ?g {
+    ?orgInT ?p ?o.
+  }
+} WHERE {
+  ?orgInT <http://lblod.data.gift/vocabularies/lmb/heeftBestuursperiode> <http://data.lblod.info/id/concept/Bestuursperiode/96efb929-5d83-48fa-bfbb-b98dfb1180c7> .
+  ?orgInT <http://data.vlaanderen.be/ns/mandaat#bindingEinde> ?einde.
+  GRAPH ?g {
+    ?orgInT ?p ?o.
+  }
+}

--- a/config/migrations/2024/20241003092900-cleanup-local-bestuursorganen.sparql
+++ b/config/migrations/2024/20241003092900-cleanup-local-bestuursorganen.sparql
@@ -1,5 +1,6 @@
 # had to split this query into several because virtuoso didn't like the number of optionals i used...
 # mandataris
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
 DELETE {
   GRAPH ?g {
     ?mandataris ?manp ?mano.
@@ -54,5 +55,19 @@ DELETE {
   ?orgInT <http://data.vlaanderen.be/ns/mandaat#bindingEinde> ?einde.
   GRAPH ?g {
     ?orgInT ?p ?o.
+  }
+};
+# link to verkiezing
+DELETE {
+  GRAPH ?g {
+    ?verkiezing mandaat:steltSamen ?huidigBestuursorgaanInDeTijd .
+  }
+
+} WHERE {
+  GRAPH ?g {
+    ?verkiezing mandaat:steltSamen ?huidigBestuursorgaanInDeTijd .
+  }
+  FILTER NOT EXISTS {
+    ?huidigBestuursorgaanInDeTijd a ?thing.
   }
 }


### PR DESCRIPTION
## Description

This removes the old 'local' bestuursorganen that were created. I ran a query and you can recognize them by their end date:

```
PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
SELECT * WHERE {
  ?s mandaat:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/822433205a41ef80005686050d7ab9e3a207cf07c0c1b3bbe5d879e7dcf363e9>.
?s ?p ?o.
}order by ?s ?p
#+end_src

#+RESULTS:
| s                                                                                                          | p                                                            | o                                                                                                          |
|------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------+------------------------------------------------------------------------------------------------------------|
| http://data.lblod.info/id/bestuursorganen/108f114533e15d7d8d7bf998fc2e5983555322b06c424c99f2938b53dd8dc109 | http://data.vlaanderen.be/ns/mandaat#bindingStart            | 2025-01-01T00:00:00                                                                                        |
| http://data.lblod.info/id/bestuursorganen/108f114533e15d7d8d7bf998fc2e5983555322b06c424c99f2938b53dd8dc109 | http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan  | http://data.lblod.info/id/bestuursorganen/822433205a41ef80005686050d7ab9e3a207cf07c0c1b3bbe5d879e7dcf363e9 |
| http://data.lblod.info/id/bestuursorganen/108f114533e15d7d8d7bf998fc2e5983555322b06c424c99f2938b53dd8dc109 | http://lblod.data.gift/vocabularies/lmb/heeftBestuursperiode | http://data.lblod.info/id/concept/Bestuursperiode/96efb929-5d83-48fa-bfbb-b98dfb1180c7                     |
| http://data.lblod.info/id/bestuursorganen/108f114533e15d7d8d7bf998fc2e5983555322b06c424c99f2938b53dd8dc109 | http://mu.semte.ch/vocabularies/core/uuid                    | 108f114533e15d7d8d7bf998fc2e5983555322b06c424c99f2938b53dd8dc109                                           |
| http://data.lblod.info/id/bestuursorganen/108f114533e15d7d8d7bf998fc2e5983555322b06c424c99f2938b53dd8dc109 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type              | http://data.vlaanderen.be/ns/besluit#Bestuursorgaan                                                        |
| http://data.lblod.info/id/bestuursorganen/108f114533e15d7d8d7bf998fc2e5983555322b06c424c99f2938b53dd8dc109 | http://www.w3.org/ns/org#hasPost                             | http://data.lblod.info/id/mandaten/037ac88360d66d1dadf4a64c6e6756b8211770bdf2964c99582819e4d0246cbc        |
| http://data.lblod.info/id/bestuursorganen/108f114533e15d7d8d7bf998fc2e5983555322b06c424c99f2938b53dd8dc109 | http://www.w3.org/ns/org#hasPost                             | http://data.lblod.info/id/mandaten/954cc646669850a296b2b57b620b467f18d71084df14296577e631a510e82847        |
| http://data.lblod.info/id/bestuursorganen/1a3500ee445e6072ec3f6a1eef01fc91b56834709f1a1af7904e0fc1d79cf881 | http://data.vlaanderen.be/ns/mandaat#bindingEinde            | 2030-12-06                                                                                                 |
| http://data.lblod.info/id/bestuursorganen/1a3500ee445e6072ec3f6a1eef01fc91b56834709f1a1af7904e0fc1d79cf881 | http://data.vlaanderen.be/ns/mandaat#bindingStart            | 2025-01-01                                                                                                 |
| http://data.lblod.info/id/bestuursorganen/1a3500ee445e6072ec3f6a1eef01fc91b56834709f1a1af7904e0fc1d79cf881 | http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan  | http://data.lblod.info/id/bestuursorganen/822433205a41ef80005686050d7ab9e3a207cf07c0c1b3bbe5d879e7dcf363e9 |
| http://data.lblod.info/id/bestuursorganen/1a3500ee445e6072ec3f6a1eef01fc91b56834709f1a1af7904e0fc1d79cf881 | http://lblod.data.gift/vocabularies/lmb/heeftBestuursperiode | http://data.lblod.info/id/concept/Bestuursperiode/96efb929-5d83-48fa-bfbb-b98dfb1180c7                     |
| http://data.lblod.info/id/bestuursorganen/1a3500ee445e6072ec3f6a1eef01fc91b56834709f1a1af7904e0fc1d79cf881 | http://mu.semte.ch/vocabularies/core/uuid                    | 1a3500ee445e6072ec3f6a1eef01fc91b56834709f1a1af7904e0fc1d79cf881                                           |
| http://data.lblod.info/id/bestuursorganen/1a3500ee445e6072ec3f6a1eef01fc91b56834709f1a1af7904e0fc1d79cf881 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type              | http://data.vlaanderen.be/ns/besluit#Bestuursorgaan                                                        |
| http://data.lblod.info/id/bestuursorganen/1a3500ee445e6072ec3f6a1eef01fc91b56834709f1a1af7904e0fc1d79cf881 | http://www.w3.org/ns/org#hasPost                             | http://data.lblod.info/id/mandaten/c0b9f9c8a97df6132fe017b68725a235be4c617db4e58707dc4ea15165fec40a        |
| http://data.lblod.info/id/bestuursorganen/1a3500ee445e6072ec3f6a1eef01fc91b56834709f1a1af7904e0fc1d79cf881 | http://www.w3.org/ns/org#hasPost                             | http://data.lblod.info/id/mandaten/8e5ff15990915b0660daa7310e4122b1551a69952d3c0679d079f96aa38dd9b6        |

```
in these results the first one is the correct one and the second our local one.
## How to test

run this migration on your database, the old bestuursorganen (and mandatarissen etc) should be gone.
