### PR TITLE
LMB-883 add migration to migrate contact info

### DIFF
--- a/config/migrations/2024/20241008131100-migrate-contact-info.sparql
+++ b/config/migrations/2024/20241008131100-migrate-contact-info.sparql
@@ -1,0 +1,18 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX schema: <http://schema.org/>
+
+INSERT {
+  GRAPH ?graph {
+    ?contact a ext:BestuurseenheidContact ;
+      ext:contactVoor ?bestuurseenheid;
+      schema:email ?email.
+  }
+}
+WHERE {
+  ?bestuurseenheid a besluit:Bestuurseenheid ;
+    mu:uuid ?id ;
+    ext:mailAdresVoorNotificaties ?email .
+  BIND(IRI(CONCAT("http://mu.semte.ch/graphs/organizations/", ?id, "/LoketLB-mandaatGebruiker")) AS ?graph)
+} 

--- a/config/migrations/2024/20241008131100-migrate-contact-info.sparql
+++ b/config/migrations/2024/20241008131100-migrate-contact-info.sparql
@@ -6,8 +6,9 @@ PREFIX schema: <http://schema.org/>
 INSERT {
   GRAPH ?graph {
     ?contact a ext:BestuurseenheidContact ;
-      ext:contactVoor ?bestuurseenheid;
-      schema:email ?email.
+      mu:uuid ?contactUuid ;
+      ext:contactVoor ?bestuurseenheid ;
+      schema:email ?email .
   }
 }
 WHERE {
@@ -15,4 +16,6 @@ WHERE {
     mu:uuid ?id ;
     ext:mailAdresVoorNotificaties ?email .
   BIND(IRI(CONCAT("http://mu.semte.ch/graphs/organizations/", ?id, "/LoketLB-mandaatGebruiker")) AS ?graph)
+  BIND(STRUUID() AS ?contactUuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/BestuurseenheidContact/", ?contactUuid)) AS ?contact)
 } 

--- a/config/migrations/2024/20241008131100-migrate-contact-info.sparql
+++ b/config/migrations/2024/20241008131100-migrate-contact-info.sparql
@@ -3,6 +3,11 @@ PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
 PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 PREFIX schema: <http://schema.org/>
 
+DELETE {
+  Graph ?oGraph {
+    ?bestuurseenheid ext:mailAdresVoorNotificaties ?email .
+  }
+}
 INSERT {
   GRAPH ?graph {
     ?contact a ext:BestuurseenheidContact ;
@@ -13,8 +18,10 @@ INSERT {
 }
 WHERE {
   ?bestuurseenheid a besluit:Bestuurseenheid ;
-    mu:uuid ?id ;
-    ext:mailAdresVoorNotificaties ?email .
+    mu:uuid ?id .
+  GRAPH ?oGraph {
+    ?bestuurseenheid ext:mailAdresVoorNotificaties ?email .
+  }
   BIND(IRI(CONCAT("http://mu.semte.ch/graphs/organizations/", ?id, "/LoketLB-mandaatGebruiker")) AS ?graph)
   BIND(STRUUID() AS ?contactUuid)
   BIND(IRI(CONCAT("http://data.lblod.info/id/BestuurseenheidContact/", ?contactUuid)) AS ?contact)


### PR DESCRIPTION
## Description

Add a migration to migrate the contact info that is used in loket to the implementation that we use in LMB. This is needed because we can't update the info on the bestuurseenheid, but we want users to be able to do that, so we need to add a resource the users can manage themselves.

## How to test

Pretty difficult to test, because we don't have the data from loket (probably because it is confidential information), but just review the query.

You can just execute a query like this before to mock some mailaddresses in the data.
```
PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
PREFIX schema: <http://schema.org/>

INSERT {
  GRAPH <http://mu.semte.ch/graphs/public> {
?bestuurseenheid ext:mailAdresVoorNotificaties "test@gmail.com" .
  }
}
WHERE {
  ?bestuurseenheid a besluit:Bestuurseenheid .
} 
```
