### PR TITLE
LMB-856: Use custom dateInput compoinent instead of displaytype datetime

### DIFF
--- a/config/form-content/mandataris-edit/form.ttl
+++ b/config/form-content/mandataris-edit/form.ttl
@@ -73,13 +73,13 @@ ext:startF
             a form:RequiredConstraint;
             form:grouping form:Bag;
             sh:path mandaat:start;
-            sh:resultMessage "Startdatum is verplicht."
+            # sh:resultMessage "Startdatum is verplicht."
         ],
         [
             a ext:ValidMandatarisDate;
             form:grouping form:Bag;
             sh:path mandaat:start;
-            sh:resultMessage "Startdatum ligt niet in de bestuursperiode."
+            # sh:resultMessage "Startdatum ligt niet in de bestuursperiode."
         ].
 ext:eindeF
     a form:Field;
@@ -93,7 +93,7 @@ ext:eindeF
             a ext:ValidMandatarisDate;
             form:grouping form:Bag;
             sh:path mandaat:einde;
-            sh:resultMessage "Einddatum ligt niet in de bestuursperiode."
+            # sh:resultMessage "Einddatum ligt niet in de bestuursperiode."
         ].
 ext:fractieF
     a form:Field;

--- a/config/form-content/mandataris-edit/form.ttl
+++ b/config/form-content/mandataris-edit/form.ttl
@@ -63,7 +63,7 @@ ext:rangordeF
     ].
 ext:startF
     a form:Field;
-    form:displayType displayTypes:dateTime;
+    form:displayType displayTypes:dateInput;
     sh:group ext:editMandatarisPG;
     sh:name "Start";
     sh:order 700;
@@ -83,7 +83,7 @@ ext:startF
         ].
 ext:eindeF
     a form:Field;
-    form:displayType displayTypes:dateTime;
+    form:displayType displayTypes:dateInput;
     sh:group ext:editMandatarisPG;
     sh:name "Einde";
     sh:order 800;

--- a/config/form-content/persoon/form.ttl
+++ b/config/form-content/persoon/form.ttl
@@ -62,7 +62,7 @@ ext:identificatorF
     ].
 ext:geboorteF
     a form:Field;
-    form:displayType displayTypes:dateTime;
+    form:displayType displayTypes:dateInput;
     sh:group ext:persoonPG;
     sh:name "Geboortedatum";
     sh:order 6;


### PR DESCRIPTION
## Description

Change the datetime displaytypes to the new custom dateInput displayType. All bestuursperiode validations should already be in place in the ttl so nothing to change there.

## How to test

1. Kill form-content 
2. Start the app
3. Follow the test steps in the frontend

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/351
