### PR TITLE
add migration to fix end dates bestuursorganen in tijd 2024-2030

### DIFF
--- a/config/migrations/2024/20241017085951-fix-bindingStart-dates.sparql
+++ b/config/migrations/2024/20241017085951-fix-bindingStart-dates.sparql
@@ -1,0 +1,23 @@
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
+PREFIX bestuursperiode: <http://data.lblod.info/id/concept/Bestuursperiode/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+DELETE {
+  GRAPH ?g {
+    ?orgaan mandaat:bindingStart ?start.
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?orgaan mandaat:bindingStart "2024-12-04T00:00:00"^^xsd:dateTime .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?orgaan lmb:heeftBestuursperiode bestuursperiode:96efb929-5d83-48fa-bfbb-b98dfb1180c7.
+    OPTIONAL {
+      ?orgaan mandaat:bindingStart ?start.
+    }
+  }
+};


### PR DESCRIPTION
## Description

Fix bestuursorganen in de tijd which have wrong or no bindingStart.

## How to test

My local data was okay, but for some reason the fake bestuursorganen in de tijd on test did not have a bindingStart. So it is difficult to test this locally, but you can check if the migration works and does not update the bindingStart of other bestuursorganen in de tijd.