### PR TITLE
add iv to ocmw's

### DIFF
--- a/config/migrations/2024/20240910102800-legislation-2025/20241022093421-new-installatievergaderingen-ocmw.sparql
+++ b/config/migrations/2024/20240910102800-legislation-2025/20241022093421-new-installatievergaderingen-ocmw.sparql
@@ -1,0 +1,26 @@
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX ivs: <http://data.lblod.info/id/concept/InstallatievergaderingStatus/>
+PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
+PREFIX bestuursperiode: <http://data.lblod.info/id/concept/Bestuursperiode/>
+
+INSERT {
+  GRAPH ?g {
+    ?installatievergadering a lmb:Installatievergadering;
+      mu:uuid ?uuid;
+      lmb:hasStatus ivs:b54dbe98-d618-4af7-9f01-791aa90774e4;
+      lmb:heeftBestuurseenheid ?bestuurseenheid;
+      lmb:heeftBestuursperiode bestuursperiode:96efb929-5d83-48fa-bfbb-b98dfb1180c7.
+  }
+}
+WHERE {
+  ?bestuurseenheid a besluit:Bestuurseenheid;
+      besluit:classificatie ?classificatie;
+      mu:uuid ?bestuurseenheidId.
+
+  FILTER (?classificatie IN (<http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002>))
+
+  BIND(STRUUID() AS ?uuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/installatievergaderingen/", STR(?uuid))) AS ?installatievergadering).
+  BIND(IRI(CONCAT("http://mu.semte.ch/graphs/organizations/", STR(?bestuurseenheidId), "/LoketLB-mandaatGebruiker")) AS ?g).
+}


### PR DESCRIPTION
## Description

OCMW's did not have an IV, this made sense because we do the IV in the corresponding municipality. However if we want to disable certain modules during the preparation of the legislature, it makes sense to have this relation as well.

## How to test

Run the migration and check if OCMW's now have IV's as well.

## Links to other PR's

- https://github.com/lblod/mandataris-service/pull/54
