### PR TITLE
add identifiers to person graph if missing

### DIFF
--- a/config/migrations/2024/20241023131900-add-identifiers-to-person-graph.sparql
+++ b/config/migrations/2024/20241023131900-add-identifiers-to-person-graph.sparql
@@ -1,0 +1,23 @@
+  PREFIX adms: <http://www.w3.org/ns/adms#>
+  PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+  PREFIX person: <http://www.w3.org/ns/person#>
+  INSERT {
+    GRAPH ?g {
+      ?s adms:identifier ?id.
+      ?id ?p ?o.
+    }
+  } WHERE {
+    GRAPH ?g {
+      ?s a person:Person.
+    }
+    ?s adms:identifier ?id.
+    ?id skos:notation ?idnr.
+    ?id ?p ?o.
+
+    FILTER NOT EXISTS {
+      GRAPH ?g {
+        ?s adms:identifier ?id.
+        ?id skos:notation ?idnr.
+      }
+    }
+  }


### PR DESCRIPTION
## Description

add identifiers to person graph if missing

## How to test

get production data and see that some identifiers were in other graphs than where the persons now resided (people moved to a different commune)
After this migration the identifiers should also be visible to the new commune
