### PR TITLE
resolve prefix issues on ldes level

### DIFF
--- a/config/ldes-delta-pusher/initialization.ts
+++ b/config/ldes-delta-pusher/initialization.ts
@@ -1,4 +1,5 @@
 import { ldesInstances } from "./ldes-instances";
+import { sparqlEscapeUri } from "mu";
 
 // this is so we can relate our instances to the bestuurseenheid they concern
 const extraConstruct = `
@@ -20,9 +21,36 @@ Object.keys(ldesInstances).forEach((stream) => {
   initialization[stream] = initializationStream;
 
   Object.keys(ldesInstances[stream].entities).forEach((type) => {
+    const transformPredicates =
+      ldesInstances[stream].entities[type].transformPredicates;
+    const transformTypes = ldesInstances[stream].entities[type].transformTypes;
+    let transformedExtraWhere = extraWhere;
+    let transformedExtraConstruct = extraConstruct;
+    if (transformPredicates) {
+      let mapping = "";
+      Object.keys(transformPredicates).forEach((from) => {
+        const to = transformPredicates[from];
+        mapping += `(${sparqlEscapeUri(from)} ${sparqlEscapeUri(to)})\n`;
+      });
+      transformedExtraWhere = `${extraWhere}
+
+      VALUES (?pFrom ?pTo) {
+        ${mapping}
+      }
+      BIND(IF(?p = ?pFrom, ?pTo, ?p) AS ?pNew)`;
+      transformedExtraConstruct = `${extraConstruct}
+      ?versionedS ?pNew ?o.`;
+    }
+    if (transformTypes) {
+      const extraTypes = transformTypes
+        .map((type) => `${sparqlEscapeUri(type)}`)
+        .join(", ");
+      transformedExtraConstruct = `${extraConstruct}
+      ?versionedS a ${extraTypes}.`;
+    }
     const typeConfig = {
-      extraConstruct,
-      extraWhere,
+      extraConstruct: transformedExtraConstruct,
+      extraWhere: transformedExtraWhere,
       filter: "",
     };
     const definition = ldesInstances[stream].entities[type];

--- a/config/ldes-delta-pusher/ldes-instances.ts
+++ b/config/ldes-delta-pusher/ldes-instances.ts
@@ -39,6 +39,16 @@ export const ldesInstances = {
         instanceFilter: `FILTER(?p NOT IN (<http://data.vlaanderen.be/ns/persoon#heeftGeboorte>, <http://www.w3.org/ns/adms#identifier>, <http://data.vlaanderen.be/ns/persoon#geslacht>))
       `,
         healingPredicates: ["http://purl.org/dc/terms/modified"],
+        transformPredicates: {
+          "http://data.vlaanderen.be/ns/persoon#gebruikteVoornaam":
+            "https://data.vlaanderen.be/ns/persoon#gebruikteVoornaam",
+          "http://data.vlaanderen.be/ns/persoon#heeftNationaliteit":
+            "https://data.vlaanderen.be/ns/persoon#heeftNationaliteit",
+          "http://data.vlaanderen.be/ns/persoon#heeftGeboorte":
+            "https://data.vlaanderen.be/ns/persoon#heeftGeboorte",
+          "http://data.vlaanderen.be/ns/persoon#geslacht":
+            "https://data.vlaanderen.be/ns/persoon#geslacht",
+        },
       },
       "http://data.vlaanderen.be/ns/besluit#Artikel": {
         specialType: true,
@@ -76,15 +86,30 @@ export const ldesInstances = {
       "http://data.vlaanderen.be/ns/mandaat#Mandaat": [
         "http://purl.org/dc/terms/modified",
       ],
-      "http://www.w3.org/ns/person#Person": [
-        "http://purl.org/dc/terms/modified",
-      ],
+      "http://www.w3.org/ns/person#Person": {
+        healingPredicates: ["http://purl.org/dc/terms/modified"],
+        transformPredicates: {
+          "http://data.vlaanderen.be/ns/persoon#gebruikteVoornaam":
+            "https://data.vlaanderen.be/ns/persoon#gebruikteVoornaam",
+          "http://data.vlaanderen.be/ns/persoon#heeftNationaliteit":
+            "https://data.vlaanderen.be/ns/persoon#heeftNationaliteit",
+          "http://data.vlaanderen.be/ns/persoon#heeftGeboorte":
+            "https://data.vlaanderen.be/ns/persoon#heeftGeboorte",
+          "http://data.vlaanderen.be/ns/persoon#geslacht":
+            "https://data.vlaanderen.be/ns/persoon#geslacht",
+        },
+      },
       "http://www.w3.org/ns/adms#Identifier": [
         "http://purl.org/dc/terms/modified",
       ],
-      "http://data.vlaanderen.be/ns/persoon#Geboorte": [
-        "http://purl.org/dc/terms/modified",
-      ],
+      "http://data.vlaanderen.be/ns/persoon#Geboorte": {
+        transformPredicates: {
+          "http://data.vlaanderen.be/ns/persoon#datum":
+            "https://data.vlaanderen.be/ns/persoon#datum",
+        },
+        transformTypes: ["https://data.vlaanderen.be/ns/persoon#Geboorte"],
+        healingPredicates: ["http://purl.org/dc/terms/modified"],
+      },
       "http://data.vlaanderen.be/ns/besluit#Artikel": {
         specialType: true,
         healingPredicates: [
@@ -121,15 +146,30 @@ export const ldesInstances = {
       "http://data.vlaanderen.be/ns/mandaat#Mandaat": [
         "http://purl.org/dc/terms/modified",
       ],
-      "http://www.w3.org/ns/person#Person": [
-        "http://purl.org/dc/terms/modified",
-      ],
+      "http://www.w3.org/ns/person#Person": {
+        healingPredicates: ["http://purl.org/dc/terms/modified"],
+        transformPredicates: {
+          "http://data.vlaanderen.be/ns/persoon#gebruikteVoornaam":
+            "https://data.vlaanderen.be/ns/persoon#gebruikteVoornaam",
+          "http://data.vlaanderen.be/ns/persoon#heeftNationaliteit":
+            "https://data.vlaanderen.be/ns/persoon#heeftNationaliteit",
+          "http://data.vlaanderen.be/ns/persoon#heeftGeboorte":
+            "https://data.vlaanderen.be/ns/persoon#heeftGeboorte",
+          "http://data.vlaanderen.be/ns/persoon#geslacht":
+            "https://data.vlaanderen.be/ns/persoon#geslacht",
+        },
+      },
       "http://www.w3.org/ns/adms#Identifier": [
         "http://purl.org/dc/terms/modified",
       ],
-      "http://data.vlaanderen.be/ns/persoon#Geboorte": [
-        "http://purl.org/dc/terms/modified",
-      ],
+      "http://data.vlaanderen.be/ns/persoon#Geboorte": {
+        transformPredicates: {
+          "http://data.vlaanderen.be/ns/persoon#datum":
+            "https://data.vlaanderen.be/ns/persoon#datum",
+        },
+        transformTypes: ["https://data.vlaanderen.be/ns/persoon#Geboorte"],
+        healingPredicates: ["http://purl.org/dc/terms/modified"],
+      },
       "http://data.vlaanderen.be/ns/besluit#Artikel": {
         specialType: true,
         healingPredicates: [

--- a/config/resources/repository.lisp
+++ b/config/resources/repository.lisp
@@ -4,8 +4,8 @@
 
 (add-prefix "besluit" "http://data.vlaanderen.be/ns/besluit#")
 (add-prefix "mandaat" "http://data.vlaanderen.be/ns/mandaat#")
-(add-prefix "persoon" "http://data.vlaanderen.be/ns/persoon#") ;;  TODO: this is incorrect, should be https
-(add-prefix "generiek" "http://data.vlaanderen.be/ns/generiek#") ;; TODO: this is incorrect, should be https
+(add-prefix "persoon" "http://data.vlaanderen.be/ns/persoon#") ;;  TODO: this is incorrect, should be https. This has been solved on the ldes level
+(add-prefix "generiek" "http://data.vlaanderen.be/ns/generiek#") ;; TODO: this is incorrect, should be https. This is not used in items that we publish so not our jurisdiction
 
 (add-prefix "dct" "http://purl.org/dc/terms/")
 (add-prefix "adms" "http://www.w3.org/ns/adms#")


### PR DESCRIPTION
## Description

This fixes the issues with the persoon prefix that should be https but is defined as http in our application.
We can just handle this by adding the predicates and type values with both http and https on the ldes.

## How to test

Run the initial sync of the ldes and notice that the predicates on persoon are defined both as http and https. Also notice that the type of geboorte is defined as both http and https.
Also notice that other types are still present in the initial dump to ldes.

Then update a person and see that the same holds for Person and Geboorte instances. 
Update another type, like Mandataris and see that it is also still written to the right LDES streams