### PR TITLE
add geboortes to person graph if missing 

### DIFF
--- a/config/migrations/2024/20241023164310-add-geboortes-to-person-graph.sparql
+++ b/config/migrations/2024/20241023164310-add-geboortes-to-person-graph.sparql
@@ -1,0 +1,23 @@
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
+PREFIX person: <http://www.w3.org/ns/person#>
+
+INSERT {
+  GRAPH ?g {
+    ?geboorte ?p ?o .
+  }
+} 
+WHERE {
+  GRAPH ?g {
+    ?s a person:Person .
+    ?s persoon:heeftGeboorte ?geboorte .
+  }
+  ?geboorte mu:uuid ?id ;
+    ?p ?o .
+
+  FILTER NOT EXISTS {
+    GRAPH ?g {
+      ?geboorte mu:uuid ?id .
+    }
+  }
+}


### PR DESCRIPTION
Description
add geboortes to person graph if missing

How to test
get production data and see that some geboortes were in other graphs than where the persons now resided (people moved to a different commune)
After this migration the geboortes should also be visible to the new commune