### PR TITLE
fix some person names as requested by Nele

### DIFF
--- a/config/migrations/2024/20241025161900-fix-person-names.sparql
+++ b/config/migrations/2024/20241025161900-fix-person-names.sparql
@@ -1,0 +1,30 @@
+PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
+DELETE {
+  GRAPH ?g {
+    <http://data.lblod.info/id/personen/5EFC792BBF82310008000050> persoon:gebruikteVoornaam ?name.
+  }
+}
+INSERT {
+  GRAPH ?g {
+    <http://data.lblod.info/id/personen/5EFC792BBF82310008000050> persoon:gebruikteVoornaam "Geert".
+  }
+}
+WHERE {
+  GRAPH ?g {
+    <http://data.lblod.info/id/personen/5EFC792BBF82310008000050> persoon:gebruikteVoornaam ?name.
+  }
+};
+DELETE {
+  GRAPH ?g {
+    ?person foaf:name ?name.
+  }
+}
+WHERE {
+  GRAPH ?g {
+    VALUES ?person {
+      <http://data.lblod.info/id/personen/62AB350D470F7A000800020F>
+      <http://data.lblod.info/id/personen/eaf99594aceab1c66cd9f5c396b45f94f3ef4ade65fe93288356ab5c4b8f44e4>
+    }
+    ?person foaf:name ?name.
+  }
+}


### PR DESCRIPTION
## Description

fix some person names as requested by Nele
## How to test

this query selects all information on the uris mentioned by the ticket
```
PREFIX foaf: <http://xmlns.com/foaf/0.1/>
PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
SELECT ?person ?p ?o WHERE {
VALUES ?person {
<http://data.lblod.info/id/personen/5D9DEE71A3ACB600080000ED>
<http://data.lblod.info/id/personen/5D9DED7DA3ACB600080000E8>
<http://data.lblod.info/id/personen/5D9DE927A3ACB600080000D9>
<http://data.lblod.info/id/personen/5D9DEB69A3ACB600080000E0>
<http://data.lblod.info/id/persoon/4d5d6354-162d-4b4a-b4ee-5a317fa0bfd2>
<http://data.lblod.info/id/personen/5D9DF2FCA3ACB600080000FA>
<http://data.lblod.info/id/persoon/7fa8a756-7d53-4ebb-b821-55c2b2e153a4>
<http://data.lblod.info/id/persoon/4ff24ac1-3e24-4f70-8ada-2e92c05382ba>
<http://data.lblod.info/id/personen/eaf99594aceab1c66cd9f5c396b45f94f3ef4ade65fe93288356ab5c4b8f44e4>
<http://data.lblod.info/id/personen/5EFC792BBF82310008000050>
<http://data.lblod.info/id/personen/62AB350D470F7A000800020F>
} 
?person ?p ?o.
VALUES ?p {
  foaf:name
  foaf:familyName
  persoon:gebruikteVoornaam
}
}
```