### PR TITLE
expose election data to ocmw as they can only pick people who have been elected

### DIFF
--- a/config/migrations/2024/20241028084700-expose-verkiezingen-to-ocmw/20241028084700-copy-verkiezingen.sparql
+++ b/config/migrations/2024/20241028084700-expose-verkiezingen-to-ocmw/20241028084700-copy-verkiezingen.sparql
@@ -1,0 +1,26 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX org: <http://www.w3.org/ns/org#>
+INSERT {
+  GRAPH ?ocmwG {
+    ?verkiezing mandaat:steltSamen ?gemeenteOrgInTijd.
+    ?verkiezing ext:copiedForOCMW ?ocmw.
+    ?verkiezing mandaat:steltSamen ?ocmwOrgInTijd.
+  }
+} WHERE {
+  ?gemeente a besluit:Bestuurseenheid .
+  ?ocmw a besluit:Bestuurseenheid .
+  ?gemeente skos:prefLabel ?name.
+  ?ocmw skos:prefLabel ?name.
+  ?gemeenteOrgInTijd mandaat:isTijdspecialisatieVan / besluit:bestuurt ?gemeente.
+  ?gemeenteOrgInTijd lmb:heeftBestuursperiode <http://data.lblod.info/id/concept/Bestuursperiode/96efb929-5d83-48fa-bfbb-b98dfb1180c7> .
+  GRAPH ?ocmwG {
+    ?ocmwOrg besluit:bestuurt ?ocmw.
+    ?ocmwOrg besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000007> .
+    ?ocmwOrgInTijd mandaat:isTijdspecialisatieVan ?ocmwOrg.
+  }
+  ?verkiezing mandaat:steltSamen ?gemeenteOrgInTijd.
+}

--- a/config/migrations/2024/20241028084700-expose-verkiezingen-to-ocmw/20241028084700-copy-verkiezingen.sparql
+++ b/config/migrations/2024/20241028084700-expose-verkiezingen-to-ocmw/20241028084700-copy-verkiezingen.sparql
@@ -21,6 +21,7 @@ INSERT {
     ?ocmwOrg besluit:bestuurt ?ocmw.
     ?ocmwOrg besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000007> .
     ?ocmwOrgInTijd mandaat:isTijdspecialisatieVan ?ocmwOrg.
+    ?ocmwOrgInTijd lmb:heeftBestuursperiode <http://data.lblod.info/id/concept/Bestuursperiode/96efb929-5d83-48fa-bfbb-b98dfb1180c7> .
   }
   ?verkiezing mandaat:steltSamen ?gemeenteOrgInTijd.
 }

--- a/config/migrations/2024/20241028084700-expose-verkiezingen-to-ocmw/20241028084701-copy-verkiezing-data.sparql
+++ b/config/migrations/2024/20241028084700-expose-verkiezingen-to-ocmw/20241028084701-copy-verkiezing-data.sparql
@@ -1,0 +1,16 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+INSERT {
+  GRAPH ?ocmwG {
+    ?verkiezing ?vp ?vo.
+  }
+} WHERE {
+  GRAPH ?ocmwG {
+    ?verkiezing mandaat:steltSamen ?gemeenteOrgInTijd.
+    ?verkiezing ext:copiedForOCMW ?ocmw.
+  }
+  ?verkiezing ?vp ?vo.
+}

--- a/config/migrations/2024/20241028084700-expose-verkiezingen-to-ocmw/20241028084702-copy-kieslijsten.sparql
+++ b/config/migrations/2024/20241028084700-expose-verkiezingen-to-ocmw/20241028084702-copy-kieslijsten.sparql
@@ -1,0 +1,17 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+INSERT {
+  GRAPH ?ocmwG {
+    ?lijst ?lp ?lo.
+  }
+} WHERE {
+  GRAPH ?ocmwG {
+    ?verkiezing mandaat:steltSamen ?gemeenteOrgInTijd.
+    ?verkiezing ext:copiedForOCMW ?ocmw.
+  }
+  ?lijst mandaat:behoortTot ?verkiezing.
+  ?lijst ?lp ?lo.
+}

--- a/config/migrations/2024/20241028084700-expose-verkiezingen-to-ocmw/20241028084703-copy-results.sparql
+++ b/config/migrations/2024/20241028084700-expose-verkiezingen-to-ocmw/20241028084703-copy-results.sparql
@@ -1,0 +1,18 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+INSERT {
+  GRAPH ?ocmwG {
+    ?res ?rp ?ro.
+  }
+} WHERE {
+  GRAPH ?ocmwG {
+    ?verkiezing mandaat:steltSamen ?gemeenteOrgInTijd.
+    ?verkiezing ext:copiedForOCMW ?ocmw.
+    ?lijst mandaat:behoortTot ?verkiezing.
+  }
+  ?res mandaat:isResultaatVoor ?lijst.
+  ?res ?rp ?ro.
+}

--- a/config/migrations/2024/20241028084700-expose-verkiezingen-to-ocmw/20241028084704-copy-persons.sparql
+++ b/config/migrations/2024/20241028084700-expose-verkiezingen-to-ocmw/20241028084704-copy-persons.sparql
@@ -1,0 +1,18 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+INSERT {
+  GRAPH ?ocmwG {
+    ?persoon ?p ?o.
+  }
+} WHERE {
+  GRAPH ?ocmwG {
+    ?verkiezing ext:copiedForOCMW ?ocmw.
+    ?lijst mandaat:behoortTot ?verkiezing.
+    ?res mandaat:isResultaatVoor ?lijst.
+    ?res mandaat:isResultaatVan ?persoon.
+  }
+  ?persoon ?p ?o.
+}

--- a/config/migrations/2024/20241028084700-expose-verkiezingen-to-ocmw/20241028084705-copy-person-data.sparql
+++ b/config/migrations/2024/20241028084700-expose-verkiezingen-to-ocmw/20241028084705-copy-person-data.sparql
@@ -1,0 +1,25 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
+INSERT {
+  GRAPH ?ocmwG {
+    ?target ?p ?o.
+  }
+} WHERE {
+  GRAPH ?ocmwG {
+    ?verkiezing ext:copiedForOCMW ?ocmw.
+    ?lijst mandaat:behoortTot ?verkiezing.
+    ?res mandaat:isResultaatVoor ?lijst.
+    ?res mandaat:isResultaatVan ?persoon.
+    VALUES ?linkP {
+      adms:identifier
+      persoon:heeftGeboorte
+    }
+    ?persoon ?linkP ?target.
+  }
+  ?target ?p ?o.
+}


### PR DESCRIPTION
## Description

expose election data to ocmw as they can only pick people who have been elected
## How to test

using https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/402, go to an ocmw of the new period and add mandataris instances after closing the IV prep. You should see person instances to select
