### PR TITLE
redirect delete of fraction to mandataris service

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -332,6 +332,10 @@ defmodule Dispatcher do
     forward(conn, [], "http://mandataris/mandatarissen/" <> id)
   end
 
+  delete "/fracties/:id", %{layer: :api_services, accept: %{json: true}} do
+    forward(conn, [], "http://mandataris/fracties/" <> id)
+  end
+
   #################################################################
   # LDES
   #################################################################

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,7 +119,7 @@ services:
     restart: always
     logging: *default-logging
   frontend:
-    image: lblod/frontend-lokaal-mandatenbeheer:0.2.6
+    image: lblod/frontend-lokaal-mandatenbeheer:0.2.7
     labels:
       - "logging=true"
     restart: always
@@ -154,7 +154,7 @@ services:
     volumes:
       - ./config/form-content:/config
   mandataris:
-    image: lblod/mandataris-service:0.1.4
+    image: lblod/mandataris-service:0.1.5
     labels:
       - "logging=true"
     restart: always


### PR DESCRIPTION
## Description

redirect delete of fraction to mandataris service
## How to test

go to the frontend and delete a fraction (e.g. in the installatievergadering). a tombstone will be erected for it immediately.

## Links to other PR's

- https://github.com/lblod/mandataris-service/pull/62
