### PR TITLE
lmb-: use gender selector display type

### DIFF
--- a/config/form-content/persoon/form.ttl
+++ b/config/form-content/persoon/form.ttl
@@ -69,7 +69,7 @@ ext:geboorteF
     sh:path ( persoon:heeftGeboorte persoon:datum ).
 ext:geslachtCodeF
     a form:Field;
-    form:displayType displayTypes:conceptSchemeSelectorWithoutMeta;
+    form:displayType displayTypes:genderSelector;
     sh:group ext:persoonPG;
     sh:name "Geslacht";
     sh:order 7;


### PR DESCRIPTION
## Description

We want the gender to be automatically filled in. We created a component for this that we registered in the frontend.

## How to test

- Use the app togheter with the frontend to use the new displaytype
- restart the form-content service for this

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/409