### PR TITLE
fix lidmaatschappen being broken when updating mandataris

### DIFF
--- a/config/ldes-delta-pusher/dispatch.ts
+++ b/config/ldes-delta-pusher/dispatch.ts
@@ -2,6 +2,7 @@ import { Changeset } from "../types";
 import { handleRegularTypes } from "./handle-regular-types";
 import { handleMandatarisType } from "./handle-mandataris-type";
 import { handleDecisionType } from "./handle-decision-type";
+import { handleMembershipType } from "./handle-membership-type";
 
 export default async function dispatch(changesets: Changeset[]) {
   const nonHistoryChangesets = filterOutNonAppChanges(changesets);
@@ -9,6 +10,7 @@ export default async function dispatch(changesets: Changeset[]) {
   handleRegularTypes(nonHistoryChangesets);
   handleMandatarisType(nonHistoryChangesets);
   handleDecisionType(nonHistoryChangesets);
+  handleMembershipType(nonHistoryChangesets);
 }
 
 function filterOutNonAppChanges(changesets: Changeset[]) {

--- a/config/ldes-delta-pusher/handle-mandataris-type.ts
+++ b/config/ldes-delta-pusher/handle-mandataris-type.ts
@@ -1,10 +1,8 @@
-import { Changeset } from "../types";
 import { querySudo } from "@lblod/mu-auth-sudo";
-import { sparqlEscapeUri, sparqlEscapeString } from "mu";
+import { Changeset } from "../types";
 import { publishInterestingSubjects } from "./handle-types-util";
+import { InterestingSubject } from "./publisher";
 import { MANDATARIS_DRAFT_STATE } from "./utils/well-known-uris";
-import { InterestingSubject, bindingToTriple } from "./publisher";
-import { v4 as uuidv4 } from "uuid";
 
 export const toMandatarisDraftState = async (subjects: string[]) => {
   const matches = await querySudo(`
@@ -45,48 +43,6 @@ const keepMandatarisTypesQuery = async (
     .filter((b) => !!b) as InterestingSubject[];
 };
 
-const addTimeInterval = async (
-  subject: InterestingSubject
-): Promise<string> => {
-  const tijdsintervalUuid = uuidv4();
-  const tijdsintervalUri = `http://data.lblod.info/id/tijdsintervallen/${tijdsintervalUuid}`;
-  const data = await querySudo(`
-    PREFIX dct: <http://purl.org/dc/terms/>
-    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-    PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
-    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-    PREFIX org: <http://www.w3.org/ns/org#>
-    PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
-    CONSTRUCT {
-      ${sparqlEscapeUri(tijdsintervalUri)} a dct:PeriodOfTime ;
-        mu:uuid ${sparqlEscapeString(tijdsintervalUuid)} ;
-        generiek:begin ?start ;
-        generiek:einde ?einde ;
-        ext:relatedTo ?bestuurseenheid .
-      ?membership org:memberDuring ${sparqlEscapeUri(tijdsintervalUri)} .
-    } WHERE {
-      GRAPH ?g {
-        <${subject.uri}> a mandaat:Mandataris ;
-          org:hasMembership ?membership ;
-          mandaat:start ?start .
-        OPTIONAL {
-          <${subject.uri}> mandaat:einde ?einde .
-        }
-      }
-      ?g ext:ownedBy ?bestuurseenheid .
-      FILTER NOT EXISTS {
-        ?g a <http://mu.semte.ch/vocabularies/ext/FormHistory> .
-      }
-      FILTER ( ?g != <http://mu.semte.ch/graphs/besluiten-consumed> )
-    }
-  `);
-  return data.results.bindings.map(bindingToTriple).join("\n");
-};
-
 export const handleMandatarisType = async (changesets: Changeset[]) => {
-  await publishInterestingSubjects(
-    changesets,
-    keepMandatarisTypesQuery,
-    addTimeInterval
-  );
+  await publishInterestingSubjects(changesets, keepMandatarisTypesQuery);
 };

--- a/config/ldes-delta-pusher/handle-membership-type.ts
+++ b/config/ldes-delta-pusher/handle-membership-type.ts
@@ -1,0 +1,74 @@
+import { Changeset } from "../types";
+import { querySudo } from "@lblod/mu-auth-sudo";
+import { sparqlEscapeUri, sparqlEscapeString } from "mu";
+import { publishInterestingSubjects } from "./handle-types-util";
+import { InterestingSubject, bindingToTriple } from "./publisher";
+import { v4 as uuidv4 } from "uuid";
+
+const addTimeInterval = async (
+  subject: InterestingSubject
+): Promise<string> => {
+  const tijdsintervalUuid = uuidv4();
+  const tijdsintervalUri = `http://data.lblod.info/id/tijdsintervallen/${tijdsintervalUuid}`;
+  const data = await querySudo(`
+    PREFIX dct: <http://purl.org/dc/terms/>
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX org: <http://www.w3.org/ns/org#>
+    PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+    CONSTRUCT {
+      ${sparqlEscapeUri(tijdsintervalUri)} a dct:PeriodOfTime ;
+        mu:uuid ${sparqlEscapeString(tijdsintervalUuid)} ;
+        generiek:begin ?start ;
+        generiek:einde ?einde ;
+        ext:relatedTo ?bestuurseenheid .
+      <${subject.uri}> org:memberDuring ${sparqlEscapeUri(tijdsintervalUri)} .
+    } WHERE {
+      GRAPH ?g {
+        ?mandataris a mandaat:Mandataris ;
+          org:hasMembership <${subject.uri}> ;
+          mandaat:start ?start .
+        OPTIONAL {
+          <${subject.uri}> mandaat:einde ?einde .
+        }
+      }
+      ?g ext:ownedBy ?bestuurseenheid .
+    }
+  `);
+  return data.results.bindings.map(bindingToTriple).join("\n");
+};
+
+const keepMembershipTypesQuery = async (
+  subjects: string[]
+): Promise<InterestingSubject[]> => {
+  const matches = await querySudo(`
+      SELECT DISTINCT ?s WHERE {
+        GRAPH ?g {
+          ?s a <http://www.w3.org/ns/org#Membership> .
+        }
+        ?g <http://mu.semte.ch/vocabularies/ext/ownedBy> ?bestuurseenheid.
+
+        VALUES ?s { ${[...subjects]
+          .map((subject) => `<${subject}>`)
+          .join(" ")} }
+      }
+    `);
+  return matches.results.bindings
+    .map((binding) => {
+      return {
+        uri: binding.s.value,
+        ldesType: { public: {}, abb: {}, internal: {} },
+        type: "http://www.w3.org/ns/org#Membership",
+      };
+    })
+    .filter((b) => !!b);
+};
+
+export const handleMembershipType = async (changesets: Changeset[]) => {
+  await publishInterestingSubjects(
+    changesets,
+    keepMembershipTypesQuery,
+    addTimeInterval
+  );
+};

--- a/config/ldes-delta-pusher/handle-types-util.ts
+++ b/config/ldes-delta-pusher/handle-types-util.ts
@@ -1,6 +1,6 @@
 import { Changeset } from "../types";
-import { InterestingSubject, publish, publishTriples } from "./publisher";
 import { log } from "./logger";
+import { InterestingSubject, publish } from "./publisher";
 
 type SubjectFilter = (subjects: string[]) => Promise<InterestingSubject[]>;
 type SubjectAddition = (subject: InterestingSubject) => Promise<string>;
@@ -54,10 +54,10 @@ export const publishInterestingSubjects = async (
   // do this serially to avoid overloading the stream endpoint
   let current: InterestingSubject | undefined;
   while ((current = interestingSubjects.pop())) {
-    await publish(current);
+    let additionalTriples = "";
     if (addedData) {
-      const additionalTriples = await addedData(current);
-      await publishTriples(current, additionalTriples);
+      additionalTriples = await addedData(current);
     }
+    await publish(current, additionalTriples);
   }
 };

--- a/config/ldes-delta-pusher/ldes-instances.ts
+++ b/config/ldes-delta-pusher/ldes-instances.ts
@@ -3,6 +3,7 @@ export const ldesInstances = {
     entities: {
       "http://data.vlaanderen.be/ns/mandaat#Mandataris": {
         specialType: true,
+        republishRelated: ["http://www.w3.org/ns/org#hasMembership"],
         healingPredicates: [
           "http://purl.org/dc/terms/modified",
           // this is the minimal config, one could also check all predicates per type, something like this,
@@ -29,9 +30,10 @@ export const ldesInstances = {
       "http://data.vlaanderen.be/ns/mandaat#Fractie": [
         "http://purl.org/dc/terms/modified",
       ],
-      "http://www.w3.org/ns/org#Membership": [
-        "http://purl.org/dc/terms/modified",
-      ],
+      "http://www.w3.org/ns/org#Membership": {
+        specialType: true,
+        healingPredicates: ["http://purl.org/dc/terms/modified"],
+      },
       "http://data.vlaanderen.be/ns/mandaat#Mandaat": [
         "http://purl.org/dc/terms/modified",
       ],
@@ -75,14 +77,16 @@ export const ldesInstances = {
     entities: {
       "http://data.vlaanderen.be/ns/mandaat#Mandataris": {
         specialType: true,
+        republishRelated: ["http://www.w3.org/ns/org#hasMembership"],
         healingPredicates: ["http://purl.org/dc/terms/modified"],
       },
       "http://data.vlaanderen.be/ns/mandaat#Fractie": [
         "http://purl.org/dc/terms/modified",
       ],
-      "http://www.w3.org/ns/org#Membership": [
-        "http://purl.org/dc/terms/modified",
-      ],
+      "http://www.w3.org/ns/org#Membership": {
+        specialType: true,
+        healingPredicates: ["http://purl.org/dc/terms/modified"],
+      },
       "http://data.vlaanderen.be/ns/mandaat#Mandaat": [
         "http://purl.org/dc/terms/modified",
       ],
@@ -135,14 +139,16 @@ export const ldesInstances = {
     entities: {
       "http://data.vlaanderen.be/ns/mandaat#Mandataris": {
         specialType: true,
+        republishRelated: ["http://www.w3.org/ns/org#hasMembership"],
         healingPredicates: ["http://purl.org/dc/terms/modified"],
       },
       "http://data.vlaanderen.be/ns/mandaat#Fractie": [
         "http://purl.org/dc/terms/modified",
       ],
-      "http://www.w3.org/ns/org#Membership": [
-        "http://purl.org/dc/terms/modified",
-      ],
+      "http://www.w3.org/ns/org#Membership": {
+        specialType: true,
+        healingPredicates: ["http://purl.org/dc/terms/modified"],
+      },
       "http://data.vlaanderen.be/ns/mandaat#Mandaat": [
         "http://purl.org/dc/terms/modified",
       ],


### PR DESCRIPTION
## Description

Because we only republished the link to tijdsinterval when a mandataris updated, this broke the representation of the membership instance on the ldes. This fixes this by:
- telling our ldes publisher to republish lidmaatschap when the mandataris is published
- having the tijdsinterval published at the same time as the other triples of the membership

## How to test

create and up date a mandataris, change fractions etc
notice that the membership is always complete on the ldes and always included if the mandataris is published
