### PR TITLE
lmb-936: remove iv from all province [migration]

### DIFF
--- a/config/migrations/2024/20241112160000-remove-iv-from-provincies.sparql
+++ b/config/migrations/2024/20241112160000-remove-iv-from-provincies.sparql
@@ -1,0 +1,23 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
+
+DELETE {
+  GRAPH ?eenheidsGraph {
+    ?installatievergadering a lmb:Installatievergadering.
+    ?installatievergadering ?p ?o.
+  }
+}
+WHERE {
+  GRAPH ?eenheidsGraph {
+    ?installatievergadering a lmb:Installatievergadering.
+    ?installatievergadering lmb:heeftBestuurseenheid ?bestuurseenheid.
+    ?installatievergadering lmb:heeftBestuursperiode ?bestuursperiode.
+  }  
+
+  ?bestuurseenheid besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000>. # Provincie
+  ?bestuursperiode lmb:startYear ?startYear.
+
+  FILTER NOT EXISTS {
+    ?bestuursperiode lmb:endYear ?endYear.
+  }
+}


### PR DESCRIPTION
## Description

Create a migration that removes all installatievergaderingen that are on a bestuursperiode connected to a bestuurseenheid that is a province.

## How to test

All provence should be able to create fracties and mandatarissen in the current `2024 - heden` bestuursperiode

