### PR TITLE
fix tombstone modified and deleted dates, don't try to create superflous tombstones

### DIFF
--- a/config/ldes-delta-pusher/ldes-instances.ts
+++ b/config/ldes-delta-pusher/ldes-instances.ts
@@ -68,6 +68,7 @@ export const ldesInstances = {
       },
       "http://www.w3.org/ns/activitystreams#Tombstone": {
         healingPredicates: ["http://purl.org/dc/terms/modified"],
+        // this is so we don't add tombstones for things that are still in another graph as a normal type
         healingFilter: `FILTER NOT EXISTS {
             GRAPH ?h {
              ?s a ?otherType.

--- a/config/ldes-delta-pusher/ldes-instances.ts
+++ b/config/ldes-delta-pusher/ldes-instances.ts
@@ -66,9 +66,16 @@ export const ldesInstances = {
           "http://purl.org/dc/terms/modified",
         ],
       },
-      "http://www.w3.org/ns/activitystreams#Tombstone": [
-        "http://purl.org/dc/terms/modified",
-      ],
+      "http://www.w3.org/ns/activitystreams#Tombstone": {
+        healingPredicates: ["http://purl.org/dc/terms/modified"],
+        healingFilter: `FILTER NOT EXISTS {
+            GRAPH ?h {
+             ?s a ?otherType.
+             FILTER(?otherType != <http://www.w3.org/ns/activitystreams#Tombstone>)
+            }
+            ?h <http://mu.semte.ch/vocabularies/ext/ownedBy> ?org.
+        }`,
+      },
     },
     graphsToExclude: ["http://mu.semte.ch/graphs/besluiten-consumed"],
     graphTypesToExclude: ["http://mu.semte.ch/vocabularies/ext/FormHistory"],
@@ -128,9 +135,16 @@ export const ldesInstances = {
           "http://purl.org/dc/terms/modified",
         ],
       },
-      "http://www.w3.org/ns/activitystreams#Tombstone": [
-        "http://purl.org/dc/terms/modified",
-      ],
+      "http://www.w3.org/ns/activitystreams#Tombstone": {
+        healingPredicates: ["http://purl.org/dc/terms/modified"],
+        healingFilter: `FILTER NOT EXISTS {
+            GRAPH ?h {
+             ?s a ?otherType.
+             FILTER(?otherType != <http://www.w3.org/ns/activitystreams#Tombstone>)
+            }
+            ?h <http://mu.semte.ch/vocabularies/ext/ownedBy> ?org.
+        }`,
+      },
     },
     graphsToExclude: ["http://mu.semte.ch/graphs/besluiten-consumed"],
     graphTypesToExclude: ["http://mu.semte.ch/vocabularies/ext/FormHistory"],
@@ -190,9 +204,16 @@ export const ldesInstances = {
           "http://purl.org/dc/terms/modified",
         ],
       },
-      "http://www.w3.org/ns/activitystreams#Tombstone": [
-        "http://purl.org/dc/terms/modified",
-      ],
+      "http://www.w3.org/ns/activitystreams#Tombstone": {
+        healingPredicates: ["http://purl.org/dc/terms/modified"],
+        healingFilter: `FILTER NOT EXISTS {
+            GRAPH ?h {
+             ?s a ?otherType.
+             FILTER(?otherType != <http://www.w3.org/ns/activitystreams#Tombstone>)
+            }
+            ?h <http://mu.semte.ch/vocabularies/ext/ownedBy> ?org.
+        }`,
+      },
     },
     graphsToExclude: ["http://mu.semte.ch/graphs/besluiten-consumed"],
     graphTypesToExclude: ["http://mu.semte.ch/vocabularies/ext/FormHistory"],

--- a/config/migrations/2024/20241113104300-fix-duplicate-modified.sparql
+++ b/config/migrations/2024/20241113104300-fix-duplicate-modified.sparql
@@ -1,0 +1,14 @@
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+DELETE {
+  GRAPH ?g {
+    ?s dct:modified ?one.
+  }
+} WHERE {
+  GRAPH ?g {
+    ?s dct:modified ?one.
+    ?s dct:modified ?two.
+  }
+  ?g ext:ownedBy ?org.
+  FILTER (?one < ?two)
+}

--- a/config/migrations/2024/20241113104301-fix-duplicate-deleted.sparql
+++ b/config/migrations/2024/20241113104301-fix-duplicate-deleted.sparql
@@ -1,0 +1,15 @@
+PREFIX astreams: <http://www.w3.org/ns/activitystreams#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+DELETE {
+  GRAPH ?g {
+    ?s astreams:deleted ?one.
+  }
+} WHERE {
+  GRAPH ?g {
+    ?s astreams:deleted ?one.
+    ?s astreams:deleted ?two.
+  }
+  ?g ext:ownedBy ?org.
+  FILTER (?one < ?two)
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -192,7 +192,7 @@ services:
   # LDES
   ##############################################################################
   ldes-delta-pusher:
-    image: redpencil/ldes-delta-pusher:0.6.0
+    image: redpencil/ldes-delta-pusher:0.6.1
     environment:
       LDES_ENDPOINT: "http://ldes-backend"
       LDES_BASE: "https://dev.mandatenbeheer.lblod.info/streams/ldes"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -198,6 +198,7 @@ services:
       LDES_BASE: "https://dev.mandatenbeheer.lblod.info/streams/ldes"
       CRON_HEALING: "0 0 0 * * *" # Every day at midnight
       AUTO_HEALING: "true"
+      SUDO_QUERY_RETRY_FOR_HTTP_STATUS_CODES: 429,500,502,503,504
       MAX_PAGE_SIZE_BYTES: 10000000
       INITIAL_STATE_LIMIT: 10000
       # for catching up after restart


### PR DESCRIPTION
## Description

add healingFilter to tombstones so it doesn't add tombstones on ldes for things that still exist in other graphs
also remove duplicate modified and deleted dates, keep the most recent one.

## How to test

- fetch the test db and ldes, restore it locally
- set the ldes delta pusher to the version in the linked pr
- have the ldes heal itself
- have the ldes heal itself again and notice that there is nothing to be healed
## Links to other PR's

- https://github.com/redpencilio/ldes-delta-pusher-service/pull/12
