### PR TITLE
Lmb 1072 | Use generiek prefix with HTTP in our app

### DIFF
--- a/config/ldes-delta-pusher/handle-membership-type.ts
+++ b/config/ldes-delta-pusher/handle-membership-type.ts
@@ -13,7 +13,8 @@ const addTimeInterval = async (
   const data = await querySudo(`
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-    PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+    PREFIX generiek: <http://data.vlaanderen.be/ns/generiek#>
+    PREFIX generiekS: <https://data.vlaanderen.be/ns/generiek#>
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     PREFIX org: <http://www.w3.org/ns/org#>
     PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
@@ -22,6 +23,8 @@ const addTimeInterval = async (
         mu:uuid ${sparqlEscapeString(tijdsintervalUuid)} ;
         generiek:begin ?start ;
         generiek:einde ?einde ;
+        generiekS:begin ?start ;
+        generiekS:einde ?einde ;
         ext:relatedTo ?bestuurseenheid .
       <${subject.uri}> org:memberDuring ${sparqlEscapeUri(tijdsintervalUri)} .
     } WHERE {

--- a/config/migrations/2024/20241120124400-generic-prefix-http.sparql
+++ b/config/migrations/2024/20241120124400-generic-prefix-http.sparql
@@ -1,0 +1,19 @@
+PREFIX generiekHttps: <https://data.vlaanderen.be/ns/generiek#>
+PREFIX generiek: <http://data.vlaanderen.be/ns/generiek#>
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o.
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?s ?pHttp ?o.
+  }
+}WHERE {
+  GRAPH ?g {
+    ?s ?p ?o.
+  }
+  FILTER (STRSTARTS(STR(?p), STR(generiekHttps:)))
+  BIND(IRI(REPLACE(STR(?p), STR(generiekHttps:), STR(generiek:))) AS ?pHttp)
+}

--- a/config/migrations/2024/20241120124400-generic-prefix-http.sparql
+++ b/config/migrations/2024/20241120124400-generic-prefix-http.sparql
@@ -5,10 +5,13 @@ INSERT {
   GRAPH ?g {
     ?s ?pHttp ?o.
   }
-}WHERE {
+}
+WHERE {
   GRAPH ?g {
+    VALUES (?p ?pHttp) { 
+      (generiekHttps:begin generiek:begin)
+      (generiekHttps:einde generiekHttps:einde)
+    }
     ?s ?p ?o.
   }
-  FILTER (STRSTARTS(STR(?p), STR(generiekHttps:)))
-  BIND(IRI(REPLACE(STR(?p), STR(generiekHttps:), STR(generiek:))) AS ?pHttp)
 }

--- a/config/migrations/2024/20241120124400-generic-prefix-http.sparql
+++ b/config/migrations/2024/20241120124400-generic-prefix-http.sparql
@@ -1,11 +1,6 @@
 PREFIX generiekHttps: <https://data.vlaanderen.be/ns/generiek#>
 PREFIX generiek: <http://data.vlaanderen.be/ns/generiek#>
 
-DELETE {
-  GRAPH ?g {
-    ?s ?p ?o.
-  }
-}
 INSERT {
   GRAPH ?g {
     ?s ?pHttp ?o.


### PR DESCRIPTION
## Description

Sometimes a triple has a generiek prefix uri with https, this should always be http except for the ldes data

## How to test

- Get one triple with the generiekHttps prefix an see if a duplicate has been added with the generiek Http prefix

## Attachments

LDES constructs these
```bash
ldes-delta-pusher-1  | DEBUG: [abb] Publishing data for subject http://data.lblod.info/id/lidmaatschappen/5C3DC54257753A000900022B:
ldes-delta-pusher-1  | <http://data.lblod.info/id/lidmaatschappen/5C3DC54257753A000900022B> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/org#Membership> .
...
ldes-delta-pusher-1  | <http://data.lblod.info/id/tijdsintervallen/2c59e367-a0be-440e-8e75-0767c19e01ae> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/PeriodOfTime> .
ldes-delta-pusher-1  | <http://data.lblod.info/id/tijdsintervallen/2c59e367-a0be-440e-8e75-0767c19e01ae> <https://data.vlaanderen.be/ns/generiek#begin> "2019-01-07T00:00:00.000Z"^^xsd:dateTime .
ldes-delta-pusher-1  | <http://data.lblod.info/id/tijdsintervallen/2c59e367-a0be-440e-8e75-0767c19e01ae> <http://data.vlaanderen.be/ns/generiek#begin> "2019-01-07T00:00:00.000Z"^^xsd:dateTime .
ldes-delta-pusher-1  | <http://data.lblod.info/id/tijdsintervallen/2c59e367-a0be-440e-8e75-0767c19e01ae> <http://mu.semte.ch/vocabularies/core/uuid> """2c59e367-a0be-440e-8e75-0767c19e01ae""" .
ldes-delta-pusher-1  | DEBUG: Sending data to LDES endpoint http://ldes-backend/abb
ldes-delta-pusher-1  | DEBUG: [public] Publishing data for subject http://data.lblod.info/id/lidmaatschappen/5C3DC54257753A000900022B:
ldes-delta-pusher-1  | <http://data.lblod.info/id/lidmaatschappen/5C3DC54257753A000900022B> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/org#Membership> .
...
ldes-delta-pusher-1  | <http://data.lblod.info/id/tijdsintervallen/2c59e367-a0be-440e-8e75-0767c19e01ae> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/PeriodOfTime> .
ldes-delta-pusher-1  | <http://data.lblod.info/id/tijdsintervallen/2c59e367-a0be-440e-8e75-0767c19e01ae> <https://data.vlaanderen.be/ns/generiek#begin> "2019-01-07T00:00:00.000Z"^^xsd:dateTime .
ldes-delta-pusher-1  | <http://data.lblod.info/id/tijdsintervallen/2c59e367-a0be-440e-8e75-0767c19e01ae> <http://data.vlaanderen.be/ns/generiek#begin> "2019-01-07T00:00:00.000Z"^^xsd:dateTime .
ldes-delta-pusher-1  | <http://data.lblod.info/id/tijdsintervallen/2c59e367-a0be-440e-8e75-0767c19e01ae> <http://mu.semte.ch/vocabularies/core/uuid> """2c59e367-a0be-440e-8e75-0767c19e01ae""" .
ldes-delta-pusher-1  | DEBUG: Sending data to LDES endpoint http://ldes-backend/public
ldes-delta-pusher-1  | DEBUG: [internal] Publishing data for subject http://data.lblod.info/id/lidmaatschappen/5C3DC54257753A000900022B:
ldes-delta-pusher-1  | <http://data.lblod.info/id/lidmaatschappen/5C3DC54257753A000900022B> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/org#Membership> .
...
ldes-delta-pusher-1  | <http://data.lblod.info/id/tijdsintervallen/2c59e367-a0be-440e-8e75-0767c19e01ae> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/PeriodOfTime> .
ldes-delta-pusher-1  | <http://data.lblod.info/id/tijdsintervallen/2c59e367-a0be-440e-8e75-0767c19e01ae> <https://data.vlaanderen.be/ns/generiek#begin> "2019-01-07T00:00:00.000Z"^^xsd:dateTime .
ldes-delta-pusher-1  | <http://data.lblod.info/id/tijdsintervallen/2c59e367-a0be-440e-8e75-0767c19e01ae> <http://data.vlaanderen.be/ns/generiek#begin> "2019-01-07T00:00:00.000Z"^^xsd:dateTime .
ldes-delta-pusher-1  | <http://data.lblod.info/id/tijdsintervallen/2c59e367-a0be-440e-8e75-0767c19e01ae> <http://mu.semte.ch/vocabularies/core/uuid> """2c59e367-a0be-440e-8e75-0767c19e01ae""" .
ldes-delta-pusher-1  | DEBUG: Sending data to LDES endpoint http://ldes-backend/internal
```