### PR TITLE
feat: remove nodebug profile from `form-content` service in dev compose

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -72,8 +72,6 @@ services:
     restart: "no"
   form-content:
     restart: "no"
-    profiles:
-      - nodebug
   mandataris:
     restart: "no"
     profiles:


### PR DESCRIPTION
## Description

Profile removed so it runs standard when developing. Last change to the service was 2 months ago

## How to test

Run drc up -d and it should spin up the service :)

