### PR TITLE
fix missing modified on tombstones

### DIFF
--- a/config/migrations/2024/20241122140200-fix-tombstone-modifieds.sparql
+++ b/config/migrations/2024/20241122140200-fix-tombstone-modifieds.sparql
@@ -1,0 +1,14 @@
+PREFIX dct: <http://purl.org/dc/terms/>
+INSERT {
+  GRAPH ?g {
+   ?s dct:modified ?time.
+  }
+} WHERE {
+  GRAPH ?g {
+    ?s a  <http://www.w3.org/ns/activitystreams#Tombstone> .
+    ?s <http://www.w3.org/ns/activitystreams#deleted> ?time.
+    FILTER NOT EXISTS {
+      ?s dct:modified ?something.
+    }
+  }
+}

--- a/config/modified/config.ts
+++ b/config/modified/config.ts
@@ -29,7 +29,6 @@ export async function filterDeltas(changeSets: Changeset[]) {
   };
   changeSets.map((changeSet) => {
     changeSet.inserts.forEach(trackModifiedSubjects);
-    changeSet.deletes.forEach(trackModifiedSubjects);
   });
 
   const ignoredGraphPrefixes = [


### PR DESCRIPTION
## Description

some tombstones didn't get a modified date. Use their deleted time as a modified date

## How to test
- Run the migration and see that you have no tombstones without a modified date
- run the old mandataris service (from before this PR https://github.com/lblod/mandataris-service/pull/71) and delete a mandataris. Your tombstone will now have a modified date again (but we should still keep the linked pr so that this extra step is not necessary)