### PR TITLE
fix tombstones missing in GN after loading ldes, weren't auto-healed

### DIFF
--- a/config/ldes-delta-pusher/ldes-instances.ts
+++ b/config/ldes-delta-pusher/ldes-instances.ts
@@ -68,8 +68,16 @@ export const ldesInstances = {
       },
       "http://www.w3.org/ns/activitystreams#Tombstone": {
         healingPredicates: ["http://purl.org/dc/terms/modified"],
-        // this is so we don't add tombstones for things that are still in another graph as a normal type
-        healingFilter: `FILTER NOT EXISTS {
+        // 1) don't care about tombstones that are already present, modified date doesn't matter (old ones didn't have it)
+        // 2) don't put tombstones for things that still have another type in another application graph
+        healingFilter: `
+        FILTER NOT EXISTS {
+          GRAPH <http://mu.semte.ch/graphs/transformed-ldes-data> {
+            ?s a <http://www.w3.org/ns/activitystreams#Tombstone>.
+          }
+        }
+
+        FILTER NOT EXISTS {
             GRAPH ?h {
              ?s a ?otherType.
              FILTER(?otherType != <http://www.w3.org/ns/activitystreams#Tombstone>)
@@ -138,7 +146,16 @@ export const ldesInstances = {
       },
       "http://www.w3.org/ns/activitystreams#Tombstone": {
         healingPredicates: ["http://purl.org/dc/terms/modified"],
-        healingFilter: `FILTER NOT EXISTS {
+        // 1) don't care about tombstones that are already present, modified date doesn't matter (old ones didn't have it)
+        // 2) don't put tombstones for things that still have another type in another application graph
+        healingFilter: `
+        FILTER NOT EXISTS {
+          GRAPH <http://mu.semte.ch/graphs/transformed-ldes-data> {
+            ?s a <http://www.w3.org/ns/activitystreams#Tombstone>.
+          }
+        }
+
+        FILTER NOT EXISTS {
             GRAPH ?h {
              ?s a ?otherType.
              FILTER(?otherType != <http://www.w3.org/ns/activitystreams#Tombstone>)
@@ -207,7 +224,16 @@ export const ldesInstances = {
       },
       "http://www.w3.org/ns/activitystreams#Tombstone": {
         healingPredicates: ["http://purl.org/dc/terms/modified"],
-        healingFilter: `FILTER NOT EXISTS {
+        // 1) don't care about tombstones that are already present, modified date doesn't matter (old ones didn't have it)
+        // 2) don't put tombstones for things that still have another type in another application graph
+        healingFilter: `
+        FILTER NOT EXISTS {
+          GRAPH <http://mu.semte.ch/graphs/transformed-ldes-data> {
+            ?s a <http://www.w3.org/ns/activitystreams#Tombstone>.
+          }
+        }
+
+        FILTER NOT EXISTS {
             GRAPH ?h {
              ?s a ?otherType.
              FILTER(?otherType != <http://www.w3.org/ns/activitystreams#Tombstone>)

--- a/config/migrations/2024/20241125151000-purge-duplicate-modifieds.sparql
+++ b/config/migrations/2024/20241125151000-purge-duplicate-modifieds.sparql
@@ -1,0 +1,29 @@
+  PREFIX dct: <http://purl.org/dc/terms/>
+  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+  DELETE {
+    GRAPH ?h {
+      ?s dct:modified ?other.
+    }
+  }
+  INSERT {
+    GRAPH ?h {
+      ?s dct:modified ?oldest.
+    }
+  }
+  WHERE {
+    GRAPH ?g {
+      ?s dct:modified ?oldest.
+    }
+    GRAPH ?h {
+      ?s dct:modified ?other.
+    }
+    FILTER NOT EXISTS {
+      ?s dct:modified ?evenOlder.
+      FILTER(?evenOlder > ?oldest)
+    }
+    ?g ext:ownedBy ?someone.
+    ?h ext:ownedBy ?someoneElse.
+
+    FILTER (?oldest > ?other)
+  }


### PR DESCRIPTION

## Description

purge duplicate modifieds, keep oldest. don't heal tombstones if they already exist, we don't really care about their modified dates
## How to test

load prod db and ldes feed, heal it, see there are barely any changes to be healed. heal the stream and see the outstanding changes are no longer there