### PR TITLE
LMB-1074 Copy people created in bcsd to ocmw graph

### DIFF
--- a/config/migrations/2024/20241128161131-move-people-created-in-bcsd.sparql
+++ b/config/migrations/2024/20241128161131-move-people-created-in-bcsd.sparql
@@ -1,0 +1,43 @@
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX person: <http://www.w3.org/ns/person#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+INSERT {
+  GRAPH ?ocmw {
+    ?persoon ?pp ?po .
+    ?identifier ?ip ?io .
+    ?geboorte ?gp ?go .
+  }
+}
+WHERE {
+  GRAPH ?gemeente {
+    ?orgaan a besluit:Bestuursorgaan ;
+      ext:isTijdelijkOrgaanIn ?bestuurseenheid ;
+      ext:origineleBestuurseenheid ?orgBestuurseenheid .
+    ?orgaanIT a besluit:Bestuursorgaan ;
+      mandaat:isTijdspecialisatieVan ?orgaan ;
+      org:hasPost ?mandaat .
+    ?mandataris org:holds ?mandaat ;
+      mandaat:isBestuurlijkeAliasVan ?persoon .
+    ?persoon a person:Person ;
+      ?pp ?po .
+    OPTIONAL {
+      ?persoon adms:identifier ?identifier .
+      ?identifier ?ip ?io .
+    }
+    OPTIONAL {
+      ?persoon persoon:heeftGeboorte ?geboorte .
+      ?geboorte ?gp ?go .
+    }
+  }
+  GRAPH ?ocmw {
+    FILTER NOT EXISTS {
+      ?persoon a person:Person .
+    }
+  }
+  ?ocmw ext:ownedBy ?orgBestuurseenheid .
+}


### PR DESCRIPTION
## Description

There is new logic that creates people created in the BCSD in the IV in the OCMW graph as well. However some people were created before this change, this migration moves them over.

## How to test

Check if the migration runs. If you want to you can check if there exist people that exist in the gemeente, linked to a ocmw orgaan and don't exist in their corresponding ocmw graph. 

## Link to other PR's
- https://github.com/lblod/mandataris-service/pull/73

