### PR TITLE
LMB-1100 fix incorrect names

### DIFF
--- a/config/migrations/2024/20241129081026-fix-incorrect-names.sparql
+++ b/config/migrations/2024/20241129081026-fix-incorrect-names.sparql
@@ -1,0 +1,128 @@
+PREFIX person: <http://www.w3.org/ns/person#>
+PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+DELETE {
+  GRAPH ?g {
+    ?persoon persoon:gebruikteVoornaam "Leen" .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?persoon persoon:gebruikteVoornaam "Marleen" .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?persoon a person:Person ;
+      foaf:familyName "Pollé" ;
+      persoon:gebruikteVoornaam "Leen" .
+  }
+  VALUES ?persoon { <http://data.lblod.info/id/personen/224f79149f20103bd1bb11ea7a406784a79f522e1920ab03557dee6a01907a77> }
+  ?g ext:ownedBy ?something .
+}
+;
+
+PREFIX person: <http://www.w3.org/ns/person#>
+PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+DELETE {
+  GRAPH ?g {
+    ?persoon persoon:gebruikteVoornaam "boer Jan" .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?persoon persoon:gebruikteVoornaam "Jan" .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?persoon a person:Person ;
+      foaf:familyName "Viaene" ;
+      persoon:gebruikteVoornaam "boer Jan" .
+  }
+  VALUES ?persoon { <http://data.lblod.info/id/personen/a21d75588cc51a5f265bdfb9ff99ff974397dd2bbd4fae01a0f2ff5b40283bc9> }
+  ?g ext:ownedBy ?something .
+}
+;
+
+PREFIX person: <http://www.w3.org/ns/person#>
+PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+DELETE {
+  GRAPH ?g {
+    ?persoon persoon:gebruikteVoornaam "Parmie Nico" .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?persoon persoon:gebruikteVoornaam "Nico" .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?persoon a person:Person ;
+      foaf:familyName "Parmentier" ;
+      persoon:gebruikteVoornaam "Parmie Nico" .
+  }
+  VALUES ?persoon { <http://data.lblod.info/id/personen/c6fd4f2a421557ce7227e24bb5828c3f12f06f295b063a9359b67b432f9ef777> }
+  ?g ext:ownedBy ?something .
+}
+;
+
+PREFIX person: <http://www.w3.org/ns/person#>
+PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+DELETE {
+  GRAPH ?g {
+    ?persoon persoon:gebruikteVoornaam "Metser Nico" .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?persoon persoon:gebruikteVoornaam "Nico" .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?persoon a person:Person ;
+      foaf:familyName "Balcaen" ;
+      persoon:gebruikteVoornaam "Metser Nico" .
+  }
+  VALUES ?persoon { <http://data.lblod.info/id/personen/9b8948be-afd0-4037-b2ab-683e19552c19> }
+  ?g ext:ownedBy ?something .
+}
+;
+
+PREFIX person: <http://www.w3.org/ns/person#>
+PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+DELETE {
+  GRAPH ?g {
+    ?persoon foaf:familyName "Van De Maele" .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?persoon foaf:familyName "Van de Maele" .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?persoon a person:Person ;
+      foaf:familyName "Van De Maele" ;
+      persoon:gebruikteVoornaam "Antoine" .
+  }
+  VALUES ?persoon { <http://data.lblod.info/id/personen/6ab9381111229cc2521c559ea8e53023a02c84cbbb7b103ba1cbf13584d3bdd5> }
+  ?g ext:ownedBy ?something .
+}

--- a/config/migrations/2024/20241129081026-fix-incorrect-names.sparql
+++ b/config/migrations/2024/20241129081026-fix-incorrect-names.sparql
@@ -2,15 +2,18 @@ PREFIX person: <http://www.w3.org/ns/person#>
 PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX dct: <http://purl.org/dc/terms/>
 
 DELETE {
   GRAPH ?g {
     ?persoon persoon:gebruikteVoornaam "Leen" .
+    ?persoon dct:modified ?oldTime .
   }
 }
 INSERT {
   GRAPH ?g {
     ?persoon persoon:gebruikteVoornaam "Marleen" .
+    ?persoon dct:modified ?now .
   }
 }
 WHERE {
@@ -18,9 +21,13 @@ WHERE {
     ?persoon a person:Person ;
       foaf:familyName "Pollé" ;
       persoon:gebruikteVoornaam "Leen" .
+    OPTIONAL {
+      ?persoon dct:modified ?oldTime.
+    }
   }
   VALUES ?persoon { <http://data.lblod.info/id/personen/224f79149f20103bd1bb11ea7a406784a79f522e1920ab03557dee6a01907a77> }
   ?g ext:ownedBy ?something .
+  BIND(NOW() as ?now)
 }
 ;
 
@@ -28,15 +35,18 @@ PREFIX person: <http://www.w3.org/ns/person#>
 PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX dct: <http://purl.org/dc/terms/>
 
 DELETE {
   GRAPH ?g {
     ?persoon persoon:gebruikteVoornaam "boer Jan" .
+    ?persoon dct:modified ?oldTime .
   }
 }
 INSERT {
   GRAPH ?g {
     ?persoon persoon:gebruikteVoornaam "Jan" .
+    ?persoon dct:modified ?now .
   }
 }
 WHERE {
@@ -44,9 +54,13 @@ WHERE {
     ?persoon a person:Person ;
       foaf:familyName "Viaene" ;
       persoon:gebruikteVoornaam "boer Jan" .
+    OPTIONAL {
+      ?persoon dct:modified ?oldTime.
+    }
   }
   VALUES ?persoon { <http://data.lblod.info/id/personen/a21d75588cc51a5f265bdfb9ff99ff974397dd2bbd4fae01a0f2ff5b40283bc9> }
   ?g ext:ownedBy ?something .
+  BIND(NOW() as ?now)
 }
 ;
 
@@ -54,15 +68,18 @@ PREFIX person: <http://www.w3.org/ns/person#>
 PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX dct: <http://purl.org/dc/terms/>
 
 DELETE {
   GRAPH ?g {
     ?persoon persoon:gebruikteVoornaam "Parmie Nico" .
+    ?persoon dct:modified ?oldTime .
   }
 }
 INSERT {
   GRAPH ?g {
     ?persoon persoon:gebruikteVoornaam "Nico" .
+    ?persoon dct:modified ?now .
   }
 }
 WHERE {
@@ -70,9 +87,13 @@ WHERE {
     ?persoon a person:Person ;
       foaf:familyName "Parmentier" ;
       persoon:gebruikteVoornaam "Parmie Nico" .
+    OPTIONAL {
+      ?persoon dct:modified ?oldTime.
+    }
   }
   VALUES ?persoon { <http://data.lblod.info/id/personen/c6fd4f2a421557ce7227e24bb5828c3f12f06f295b063a9359b67b432f9ef777> }
   ?g ext:ownedBy ?something .
+  BIND(NOW() as ?now)
 }
 ;
 
@@ -80,15 +101,18 @@ PREFIX person: <http://www.w3.org/ns/person#>
 PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX dct: <http://purl.org/dc/terms/>
 
 DELETE {
   GRAPH ?g {
     ?persoon persoon:gebruikteVoornaam "Metser Nico" .
+    ?persoon dct:modified ?oldTime .
   }
 }
 INSERT {
   GRAPH ?g {
     ?persoon persoon:gebruikteVoornaam "Nico" .
+    ?persoon dct:modified ?now .
   }
 }
 WHERE {
@@ -96,9 +120,13 @@ WHERE {
     ?persoon a person:Person ;
       foaf:familyName "Balcaen" ;
       persoon:gebruikteVoornaam "Metser Nico" .
+    OPTIONAL {
+      ?persoon dct:modified ?oldTime.
+    }
   }
   VALUES ?persoon { <http://data.lblod.info/id/personen/9b8948be-afd0-4037-b2ab-683e19552c19> }
   ?g ext:ownedBy ?something .
+  BIND(NOW() as ?now)
 }
 ;
 
@@ -106,15 +134,18 @@ PREFIX person: <http://www.w3.org/ns/person#>
 PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX dct: <http://purl.org/dc/terms/>
 
 DELETE {
   GRAPH ?g {
     ?persoon foaf:familyName "Van De Maele" .
+    ?persoon dct:modified ?oldTime .
   }
 }
 INSERT {
   GRAPH ?g {
     ?persoon foaf:familyName "Van de Maele" .
+    ?persoon dct:modified ?now .
   }
 }
 WHERE {
@@ -122,7 +153,11 @@ WHERE {
     ?persoon a person:Person ;
       foaf:familyName "Van De Maele" ;
       persoon:gebruikteVoornaam "Antoine" .
+    OPTIONAL {
+      ?persoon dct:modified ?oldTime.
+    }
   }
   VALUES ?persoon { <http://data.lblod.info/id/personen/6ab9381111229cc2521c559ea8e53023a02c84cbbb7b103ba1cbf13584d3bdd5> }
   ?g ext:ownedBy ?something .
+  BIND(NOW() as ?now)
 }


### PR DESCRIPTION
## Description

Fix wrong names verkiezingsresultaten from helpdesk. 
This PR only fixes the exact ones, there are also issues with capitilization, but that is still ongoing.

## How to test

Just check if you can run the migration and whether e.g "boer Jan" is still used in the database.
