### PR TITLE
disallow setting classification code to nothing, fix missing classification code organs

### DIFF
--- a/config/form-content/bestuursorgaan/form.ttl
+++ b/config/form-content/bestuursorgaan/form.ttl
@@ -38,7 +38,7 @@ ext:bestuursorgaanClassificatieCodeF
             a form:RequiredConstraint;
             form:grouping form:Bag;
             sh:path <http://data.vlaanderen.be/ns/besluit#classificatie>;
-            sh:resultMessage "Classificatiecode is verplicht."
+            sh:resultMessage "Type is verplicht."
     ];
     form:options """{"conceptScheme":"http://data.lblod.info/id/conceptscheme/LokaalOrgaanClassificatieCode","searchEnabled":true}""".
 ext:deactivatedAtF

--- a/config/form-content/bestuursorgaan/form.ttl
+++ b/config/form-content/bestuursorgaan/form.ttl
@@ -33,6 +33,13 @@ ext:bestuursorgaanClassificatieCodeF
     sh:name "Type";
     sh:order 2;
     sh:path <http://data.vlaanderen.be/ns/besluit#classificatie>;
+    form:validatedBy
+        [
+            a form:RequiredConstraint;
+            form:grouping form:Bag;
+            sh:path <http://data.vlaanderen.be/ns/besluit#classificatie>;
+            sh:resultMessage "Classificatiecode is verplicht."
+    ];
     form:options """{"conceptScheme":"http://data.lblod.info/id/conceptscheme/LokaalOrgaanClassificatieCode","searchEnabled":true}""".
 ext:deactivatedAtF
     a form:Field;

--- a/config/migrations/2024/20241202200400-fix-missing-classification-codes.sparql
+++ b/config/migrations/2024/20241202200400-fix-missing-classification-codes.sparql
@@ -1,0 +1,17 @@
+  PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+  PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+  INSERT {
+    GRAPH ?g {
+      ?org besluit:classificatie <http://data.lblod.info/id/lb-orgaan-classificatiecode/afc54ba6-f649-4941-82e4-38b9512b072d>.
+    }
+  } WHERE {
+    GRAPH ?g {
+      ?orgT mandaat:isTijdspecialisatieVan ?org.
+      FILTER NOT EXISTS {
+        ?org besluit:classificatie ?class.
+      }
+    }
+    ?g ext:ownedBy ?someone.
+
+  }


### PR DESCRIPTION
## Description

Merchtem managed to create a custom organ and then clear its classification. This brought the system in an unexpected state and suddenly they couldn't edit the fractions of mandatarises (true story).
## How to test

See that merksem now has their custom org back and that they can edit their mandataris instances again.