### PR TITLE
delete mandatarissen entered in wrong period with tombstones

### DIFF
--- a/config/migrations/2024/20241204134500-delete-mandatarissen-wrong-period.sparql
+++ b/config/migrations/2024/20241204134500-delete-mandatarissen-wrong-period.sparql
@@ -1,0 +1,60 @@
+  PREFIX dct: <http://purl.org/dc/terms/>
+  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+  PREFIX astreams: <http://www.w3.org/ns/activitystreams#>
+  PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+  DELETE {
+    GRAPH ?g {
+      ?mandataris ?p ?o.
+    }
+  }
+  INSERT {
+    GRAPH ?g {
+      ?mandataris a astreams:Tombstone.
+      ?mandataris dct:modified ?now .
+      ?mandataris astreams:deleted ?now .
+      ?mandataris astreams:formerType mandaat:Mandataris .
+    }
+  } WHERE {
+    VALUES ?mandataris {
+      <http://data.lblod.info/id/mandatarissen/674B5AC7C4FF9F63C39D6F05>
+      <http://data.lblod.info/id/mandatarissen/674B5BADC4FF9F63C39D6F07>
+      <http://data.lblod.info/id/mandatarissen/674B5B7FC4FF9F63C39D6F06>
+      <http://data.lblod.info/id/mandatarissen/664DEF791F8F2C3570D407F8>
+      <http://data.lblod.info/id/mandatarissen/672A43D2BB97C1379BFE1333>
+      <http://data.lblod.info/id/mandatarissen/6d68d4ee-1510-4f9e-ad55-c14efbb22532>
+      <http://data.lblod.info/id/mandatarissen/438efc35-85bc-4153-9b33-1b600aecf25b>
+      <http://data.lblod.info/id/mandatarissen/656DDA716B73131F22099FF1>
+      <http://data.lblod.info/id/mandatarissen/5DA95B51A3ACB600080002C7>
+      <http://data.lblod.info/id/mandatarissen/2c60bb12-61ba-4e41-a046-ac8ec02a29cf>
+      <http://data.lblod.info/id/mandatarissen/c550d03e-7ee3-4462-8a06-43d905d71dc3>
+      <http://data.lblod.info/id/mandatarissen/674B5C91C4FF9F63C39D6F08>
+      <http://data.lblod.info/id/mandatarissen/674B6719C4FF9F63C39D6F0A>
+      <http://data.lblod.info/id/mandatarissen/a5411df6-054a-47c1-b2b2-d45664f132d7>
+      <http://data.lblod.info/id/mandatarissen/5C1386B298360D0009000311>
+      <http://data.lblod.info/id/mandatarissen/3fb94a70-c27f-437a-b74d-23341a398e20>
+      <http://data.lblod.info/id/mandatarissen/bc966852-d742-47fa-9c47-baeba85532da>
+      <http://data.lblod.info/id/mandatarissen/5dd3afa2-6f0a-4bb3-82f7-c71349cdb267>
+      <http://data.lblod.info/id/mandatarissen/2b422bca-83ae-445b-84b8-dcb2bdde91de>
+      <http://data.lblod.info/id/mandatarissen/3bb2ca19-07b0-43ff-a7c2-b5b2cccc8a2b>
+      <http://data.lblod.info/id/mandatarissen/caa56139-04b1-4707-ad68-b3adc1c27329>
+      <http://data.lblod.info/id/mandatarissen/d915b6f1-a04d-4e99-9a48-5906d9059a5e>
+      <http://data.lblod.info/id/mandatarissen/a0789acb-06a2-403e-8a08-dfd2c9f36713>
+      <http://data.lblod.info/id/mandatarissen/659ae3f5-3d0d-469e-a096-383860bebb35>
+      <http://data.lblod.info/id/mandatarissen/17ed43ed-c3e9-4d06-80dc-389aea15bd2a>
+      <http://data.lblod.info/id/mandatarissen/674B5DC0C4FF9F63C39D6F09>
+      <http://data.lblod.info/id/mandatarissen/1a13123c-ace6-4640-9bf0-9cb0f07ef17c>
+      <http://data.lblod.info/id/mandatarissen/0bd64556-bfde-40f1-b0d8-f5fe9de559c2>
+      <http://data.lblod.info/id/mandatarissen/fc6c77d0-238c-4981-9fd5-71a8fdeb7841>
+      <http://data.lblod.info/id/mandatarissen/ca53dcd3-a152-4b96-99f6-eafc27c939cd>
+      <http://data.lblod.info/id/mandatarissen/db902f80-442e-409e-b5ec-725d3f119015>
+      <http://data.lblod.info/id/mandatarissen/beb4d9ba-452b-40dd-9b29-9d9faa59f111>
+      <http://data.lblod.info/id/mandatarissen/58ea27d4-93c9-4968-b5fa-1dc084034d66>
+      <http://data.lblod.info/id/mandatarissen/56878d70-a9f7-48fa-a4a1-fe3e2d0ce6d5>
+      <http://data.lblod.info/id/mandatarissen/8169d0f4-6522-4e1b-aede-b6158a524e43>
+      <http://data.lblod.info/id/mandatarissen/db00316e-5817-4866-bc83-8af5e9f5e658>
+    }
+    GRAPH ?g {
+      ?mandataris ?p ?o.
+    }
+    ?g ext:ownedBy ?org.
+  }

--- a/config/migrations/2024/20241204134500-delete-mandatarissen-wrong-period.sparql
+++ b/config/migrations/2024/20241204134500-delete-mandatarissen-wrong-period.sparql
@@ -16,42 +16,62 @@
     }
   } WHERE {
     VALUES ?mandataris {
-      <http://data.lblod.info/id/mandatarissen/674B5AC7C4FF9F63C39D6F05>
-      <http://data.lblod.info/id/mandatarissen/674B5BADC4FF9F63C39D6F07>
-      <http://data.lblod.info/id/mandatarissen/674B5B7FC4FF9F63C39D6F06>
-      <http://data.lblod.info/id/mandatarissen/664DEF791F8F2C3570D407F8>
-      <http://data.lblod.info/id/mandatarissen/672A43D2BB97C1379BFE1333>
-      <http://data.lblod.info/id/mandatarissen/6d68d4ee-1510-4f9e-ad55-c14efbb22532>
-      <http://data.lblod.info/id/mandatarissen/438efc35-85bc-4153-9b33-1b600aecf25b>
-      <http://data.lblod.info/id/mandatarissen/656DDA716B73131F22099FF1>
-      <http://data.lblod.info/id/mandatarissen/5DA95B51A3ACB600080002C7>
-      <http://data.lblod.info/id/mandatarissen/2c60bb12-61ba-4e41-a046-ac8ec02a29cf>
-      <http://data.lblod.info/id/mandatarissen/c550d03e-7ee3-4462-8a06-43d905d71dc3>
-      <http://data.lblod.info/id/mandatarissen/674B5C91C4FF9F63C39D6F08>
-      <http://data.lblod.info/id/mandatarissen/674B6719C4FF9F63C39D6F0A>
-      <http://data.lblod.info/id/mandatarissen/a5411df6-054a-47c1-b2b2-d45664f132d7>
-      <http://data.lblod.info/id/mandatarissen/5C1386B298360D0009000311>
-      <http://data.lblod.info/id/mandatarissen/3fb94a70-c27f-437a-b74d-23341a398e20>
-      <http://data.lblod.info/id/mandatarissen/bc966852-d742-47fa-9c47-baeba85532da>
-      <http://data.lblod.info/id/mandatarissen/5dd3afa2-6f0a-4bb3-82f7-c71349cdb267>
-      <http://data.lblod.info/id/mandatarissen/2b422bca-83ae-445b-84b8-dcb2bdde91de>
-      <http://data.lblod.info/id/mandatarissen/3bb2ca19-07b0-43ff-a7c2-b5b2cccc8a2b>
-      <http://data.lblod.info/id/mandatarissen/caa56139-04b1-4707-ad68-b3adc1c27329>
-      <http://data.lblod.info/id/mandatarissen/d915b6f1-a04d-4e99-9a48-5906d9059a5e>
-      <http://data.lblod.info/id/mandatarissen/a0789acb-06a2-403e-8a08-dfd2c9f36713>
-      <http://data.lblod.info/id/mandatarissen/659ae3f5-3d0d-469e-a096-383860bebb35>
-      <http://data.lblod.info/id/mandatarissen/17ed43ed-c3e9-4d06-80dc-389aea15bd2a>
-      <http://data.lblod.info/id/mandatarissen/674B5DC0C4FF9F63C39D6F09>
-      <http://data.lblod.info/id/mandatarissen/1a13123c-ace6-4640-9bf0-9cb0f07ef17c>
-      <http://data.lblod.info/id/mandatarissen/0bd64556-bfde-40f1-b0d8-f5fe9de559c2>
-      <http://data.lblod.info/id/mandatarissen/fc6c77d0-238c-4981-9fd5-71a8fdeb7841>
-      <http://data.lblod.info/id/mandatarissen/ca53dcd3-a152-4b96-99f6-eafc27c939cd>
-      <http://data.lblod.info/id/mandatarissen/db902f80-442e-409e-b5ec-725d3f119015>
-      <http://data.lblod.info/id/mandatarissen/beb4d9ba-452b-40dd-9b29-9d9faa59f111>
-      <http://data.lblod.info/id/mandatarissen/58ea27d4-93c9-4968-b5fa-1dc084034d66>
-      <http://data.lblod.info/id/mandatarissen/56878d70-a9f7-48fa-a4a1-fe3e2d0ce6d5>
-      <http://data.lblod.info/id/mandatarissen/8169d0f4-6522-4e1b-aede-b6158a524e43>
-      <http://data.lblod.info/id/mandatarissen/db00316e-5817-4866-bc83-8af5e9f5e658>
+<http://data.lblod.info/id/mandatarissen/438efc35-85bc-4153-9b33-1b600aecf25b>
+<http://data.lblod.info/id/mandatarissen/438efc35-85bc-4153-9b33-1b600aecf25b>
+<http://data.lblod.info/id/mandatarissen/2c60bb12-61ba-4e41-a046-ac8ec02a29cf>
+<http://data.lblod.info/id/mandatarissen/c550d03e-7ee3-4462-8a06-43d905d71dc3>
+<http://data.lblod.info/id/mandatarissen/672A43D2BB97C1379BFE1333>
+<http://data.lblod.info/id/mandatarissen/6d68d4ee-1510-4f9e-ad55-c14efbb22532>
+<http://data.lblod.info/id/mandatarissen/beb4d9ba-452b-40dd-9b29-9d9faa59f111>
+<http://data.lblod.info/id/mandatarissen/58ea27d4-93c9-4968-b5fa-1dc084034d66>
+<http://data.lblod.info/id/mandatarissen/db902f80-442e-409e-b5ec-725d3f119015>
+<http://data.lblod.info/id/mandatarissen/56878d70-a9f7-48fa-a4a1-fe3e2d0ce6d5>
+<http://data.lblod.info/id/mandatarissen/8169d0f4-6522-4e1b-aede-b6158a524e43>
+<http://data.lblod.info/id/mandatarissen/db00316e-5817-4866-bc83-8af5e9f5e658>
+<http://data.lblod.info/id/mandatarissen/ee999b00-1c65-4803-8bb2-2916b4c3c152>
+<http://data.lblod.info/id/mandatarissen/788a280e-c661-4988-a55f-823075a63723>
+<http://data.lblod.info/id/mandatarissen/215d3afe-08b7-4606-8be2-c5a2b14cecbd>
+<http://data.lblod.info/id/mandatarissen/4b8962a2-6b61-414f-b2cc-6c1f88c4c162>
+<http://data.lblod.info/id/mandatarissen/6cf35828-1d6b-45e3-bd22-9683aec35d90>
+<http://data.lblod.info/id/mandatarissen/e76e4fba-3728-465b-b0df-e9fbe6e55522>
+<http://data.lblod.info/id/mandatarissen/0c4e9b8e-9e69-4b53-8b87-b30e6dd82fb9>
+<http://data.lblod.info/id/mandatarissen/209b3907-e375-46f6-b267-f2106f11e2ec>
+<http://data.lblod.info/id/mandatarissen/68f431e4-b618-4254-b63c-a57b926d6d17>
+<http://data.lblod.info/id/mandatarissen/e2a081b6-554d-45b5-a347-0fa3072f53a2>
+<http://data.lblod.info/id/mandatarissen/f098f7f2-ba81-4b01-89a5-a34d7a09c48b>
+<http://data.lblod.info/id/mandatarissen/dc083843-3cd6-46f1-b6e0-0b4699b5fab0>
+<http://data.lblod.info/id/mandatarissen/5e2d7ca3-9f08-4fbd-866f-dffc2f1e1306>
+<http://data.lblod.info/id/mandatarissen/5a43e052-7388-4f51-bcef-5ea84d0507f3>
+<http://data.lblod.info/id/mandatarissen/05fd46cb-e543-4fd3-95db-7445b5584e78>
+<http://data.lblod.info/id/mandatarissen/2a8abe8f-7840-4574-ae75-32037aacf959>
+<http://data.lblod.info/id/mandatarissen/0db6c1a6-1b5b-42cf-977a-350503c9608b>
+<http://data.lblod.info/id/mandatarissen/73a27e0d-ddbf-49ed-84cf-0f1c46455471>
+<http://data.lblod.info/id/mandatarissen/39548c75-4b08-4759-b8ff-c939e9d77bd0>
+<http://data.lblod.info/id/mandatarissen/28f11873-065f-4150-aa06-75f84957931f>
+<http://data.lblod.info/id/mandatarissen/b47ad8e2-1085-4f06-9b24-ef702f2884f3>
+<http://data.lblod.info/id/mandatarissen/4970bdb9-6f23-451e-8398-525c095c301b>
+<http://data.lblod.info/id/mandatarissen/3fb94a70-c27f-437a-b74d-23341a398e20>
+<http://data.lblod.info/id/mandatarissen/674B5B7FC4FF9F63C39D6F06>
+<http://data.lblod.info/id/mandatarissen/674B5AC7C4FF9F63C39D6F05>
+<http://data.lblod.info/id/mandatarissen/5C1386B298360D0009000311>
+<http://data.lblod.info/id/mandatarissen/674B5C91C4FF9F63C39D6F08>
+<http://data.lblod.info/id/mandatarissen/674B6719C4FF9F63C39D6F0A>
+<http://data.lblod.info/id/mandatarissen/bc966852-d742-47fa-9c47-baeba85532da>
+<http://data.lblod.info/id/mandatarissen/5dd3afa2-6f0a-4bb3-82f7-c71349cdb267>
+<http://data.lblod.info/id/mandatarissen/a5411df6-054a-47c1-b2b2-d45664f132d7>
+<http://data.lblod.info/id/mandatarissen/2b422bca-83ae-445b-84b8-dcb2bdde91de>
+<http://data.lblod.info/id/mandatarissen/ca53dcd3-a152-4b96-99f6-eafc27c939cd>
+<http://data.lblod.info/id/mandatarissen/674B5BADC4FF9F63C39D6F07>
+<http://data.lblod.info/id/mandatarissen/3bb2ca19-07b0-43ff-a7c2-b5b2cccc8a2b>
+<http://data.lblod.info/id/mandatarissen/caa56139-04b1-4707-ad68-b3adc1c27329>
+<http://data.lblod.info/id/mandatarissen/659ae3f5-3d0d-469e-a096-383860bebb35>
+<http://data.lblod.info/id/mandatarissen/d915b6f1-a04d-4e99-9a48-5906d9059a5e>
+<http://data.lblod.info/id/mandatarissen/a0789acb-06a2-403e-8a08-dfd2c9f36713>
+<http://data.lblod.info/id/mandatarissen/17ed43ed-c3e9-4d06-80dc-389aea15bd2a>
+<http://data.lblod.info/id/mandatarissen/fc6c77d0-238c-4981-9fd5-71a8fdeb7841>
+<http://data.lblod.info/id/mandatarissen/1a13123c-ace6-4640-9bf0-9cb0f07ef17c>
+<http://data.lblod.info/id/mandatarissen/674B5DC0C4FF9F63C39D6F09>
+<http://data.lblod.info/id/mandatarissen/0bd64556-bfde-40f1-b0d8-f5fe9de559c2>
     }
     GRAPH ?g {
       ?mandataris ?p ?o.


### PR DESCRIPTION
> [!WARNING]
> don't merge until we checked with the municipalities that did not actively request this.

## Description

The mandatarissen are deleted by uri. The query used to fetch them was:

```
  PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
  PREFIX bestuursperiode: <http://data.lblod.info/id/concept/Bestuursperiode/>
  PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
  PREFIX org: <http://www.w3.org/ns/org#>
  PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
  PREFIX foaf: <http://xmlns.com/foaf/0.1/>
  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
  PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
  SELECT distinct ?mandataris ?label ?labelE ?firstname ?name WHERE {
    ?mandataris a mandaat:Mandataris .
    ?mandataris mandaat:start ?start.
    FILTER(?start > "2024-11-30T23:00:00Z"^^xsd:dateTime)
    ?mandataris org:holds ?mandaat.
    ?orgInT org:hasPost ?mandaat.
    ?orgInT lmb:heeftBestuursperiode bestuursperiode:a2b977a3-ce68-4e42-80a6-4397f66fc5ca.
    ?orgInT mandaat:isTijdspecialisatieVan ?org.
    ?org skos:prefLabel ?label.
    ?org besluit:bestuurt ?eenheid.
    ?eenheid skos:prefLabel ?labelE.
    ?mandataris mandaat:isBestuurlijkeAliasVan ?persoon.
    ?persoon foaf:familyName ?name.
?persoon persoon:gebruikteVoornaam ?firstname.
GRAPH ?g {
  ?mandataris a mandaat:Mandataris .
} 
?g ext:ownedBy ?someone.
  } order by ?labelE
```
## How to test

run this on a prod dump and verify the requested mandatarissen are gone.