### PR TITLE
lmb-1142: add migration to add the ovo and kbo number to Borsbeek

### DIFF
--- a/config/migrations/2024/20241204163100-add-ovo-and-kbo-to-borsbbeek.sparql
+++ b/config/migrations/2024/20241204163100-add-ovo-and-kbo-to-borsbbeek.sparql
@@ -1,0 +1,14 @@
+ PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+ PREFIX dcterms: <http://purl.org/dc/terms/>
+ 
+INSERT {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+      <http://data.lblod.info/id/bestuurseenheden/4b44e6f1-113b-4692-b149-44a889b215f2> dcterms:identifier """OVO002030""" . # OVO
+      <http://data.lblod.info/id/bestuurseenheden/4b44e6f1-113b-4692-b149-44a889b215f2> dcterms:identifier """0207509229""" . # KBO
+    }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/bestuurseenheden/4b44e6f1-113b-4692-b149-44a889b215f2>  a besluit:Bestuurseenheid. # Borsbeek
+  }
+}


### PR DESCRIPTION
## Description

Migration that adds the ovo and kbo number for borsbeek

## How to test

Query should include the kbo and ovo number like it does for the commented bestuurseenheid
```
  PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>

    SELECT *
        WHERE {
          GRAPH ?g {
            VALUES ?b {
            # <http://data.lblod.info/id/bestuurseenheden/003e84121111866af60611a59e13d4c478718f60472655936edec1e352a34c5f>
            <http://data.lblod.info/id/bestuurseenheden/4b44e6f1-113b-4692-b149-44a889b215f2>  # Borsbeek
            }
            ?b a besluit:Bestuurseenheid.
            ?b ?p ?o.
          }
        }
```
