### PR TITLE
lmb-1111 | create query that will link the non linked mandatarissen

### DIFF
--- a/config/migrations/2024/20241205154800-link-not-linked-mandatarissen-from-past-1.sparql
+++ b/config/migrations/2024/20241205154800-link-not-linked-mandatarissen-from-past-1.sparql
@@ -20,7 +20,7 @@ WHERE {
     OPTIONAL {
       ?mandataris mandaat:einde ?mandatarisEinde.
     }
-    ?mandaat org:role ?bfCode.
+    ?mandaat org:role bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000011. # Gemeenteraadslid
     ?mandaat ^org:hasPost ?bestuursorgaan.
     ?bestuursorgaan mandaat:isTijdspecialisatieVan ?bestuursorgaanInTijd.
     ?bestuursorgaan lmb:heeftBestuursperiode ?bestuursperiode.
@@ -33,7 +33,7 @@ WHERE {
     OPTIONAL {
       ?linkedMandataris mandaat:einde ?mandatarisEinde.
     }
-    ?lmandaat org:role ?linkedBfCode.
+    ?lmandaat org:role bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000015. # Lid RMW
     ?lmandaat ^org:hasPost ?lbestuursorgaan.
     ?lbestuursorgaan mandaat:isTijdspecialisatieVan ?lbestuursorgaanInTijd.
     ?lbestuursorgaan lmb:heeftBestuursperiode ?bestuursperiode.
@@ -41,7 +41,4 @@ WHERE {
 
   FILTER (?mandataris != ?linkedMandataris)
   BIND (<http://data.lblod.info/id/concept/Bestuursperiode/96efb929-5d83-48fa-bfbb-b98dfb1180c7> AS ?bestuursperiode) # 2024 - heden
-  VALUES (?bfCode ?linkedBfCode) {
-    (bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000011 bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000015) # Gemeenteraadslid | Lid RMV
-  }
 }

--- a/config/migrations/2024/20241205154800-link-not-linked-mandatarissen-from-past-2.sparql
+++ b/config/migrations/2024/20241205154800-link-not-linked-mandatarissen-from-past-2.sparql
@@ -42,6 +42,6 @@ WHERE {
   FILTER (?mandataris != ?linkedMandataris)
   BIND (<http://data.lblod.info/id/concept/Bestuursperiode/96efb929-5d83-48fa-bfbb-b98dfb1180c7> AS ?bestuursperiode) # 2024 - heden
   VALUES (?bfCode ?linkedBfCode) {
-    (bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000011 bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000015) # Gemeenteraadslid | Lid RMV
+    (bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000012 bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000016) # Voorzitter Gemeenteraad | Voorzitter RMV
   }
 }

--- a/config/migrations/2024/20241205154800-link-not-linked-mandatarissen-from-past-2.sparql
+++ b/config/migrations/2024/20241205154800-link-not-linked-mandatarissen-from-past-2.sparql
@@ -20,7 +20,7 @@ WHERE {
     OPTIONAL {
       ?mandataris mandaat:einde ?mandatarisEinde.
     }
-    ?mandaat org:role ?bfCode.
+    ?mandaat org:role bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000012. # Voorzitter Gemeenteraad
     ?mandaat ^org:hasPost ?bestuursorgaan.
     ?bestuursorgaan mandaat:isTijdspecialisatieVan ?bestuursorgaanInTijd.
     ?bestuursorgaan lmb:heeftBestuursperiode ?bestuursperiode.
@@ -33,7 +33,7 @@ WHERE {
     OPTIONAL {
       ?linkedMandataris mandaat:einde ?mandatarisEinde.
     }
-    ?lmandaat org:role ?linkedBfCode.
+    ?lmandaat org:role bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000016. # Voorzitter RMW
     ?lmandaat ^org:hasPost ?lbestuursorgaan.
     ?lbestuursorgaan mandaat:isTijdspecialisatieVan ?lbestuursorgaanInTijd.
     ?lbestuursorgaan lmb:heeftBestuursperiode ?bestuursperiode.
@@ -41,7 +41,4 @@ WHERE {
 
   FILTER (?mandataris != ?linkedMandataris)
   BIND (<http://data.lblod.info/id/concept/Bestuursperiode/96efb929-5d83-48fa-bfbb-b98dfb1180c7> AS ?bestuursperiode) # 2024 - heden
-  VALUES (?bfCode ?linkedBfCode) {
-    (bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000012 bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000016) # Voorzitter Gemeenteraad | Voorzitter RMV
-  }
 }

--- a/config/migrations/2024/20241205154800-link-not-linked-mandatarissen-from-past-3.sparql
+++ b/config/migrations/2024/20241205154800-link-not-linked-mandatarissen-from-past-3.sparql
@@ -20,7 +20,7 @@ WHERE {
     OPTIONAL {
       ?mandataris mandaat:einde ?mandatarisEinde.
     }
-    ?mandaat org:role ?bfCode.
+    ?mandaat org:role bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000014. # Schepen
     ?mandaat ^org:hasPost ?bestuursorgaan.
     ?bestuursorgaan mandaat:isTijdspecialisatieVan ?bestuursorgaanInTijd.
     ?bestuursorgaan lmb:heeftBestuursperiode ?bestuursperiode.
@@ -33,7 +33,7 @@ WHERE {
     OPTIONAL {
       ?linkedMandataris mandaat:einde ?mandatarisEinde.
     }
-    ?lmandaat org:role ?linkedBfCode.
+    ?lmandaat org:role bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000017. # Lid Vast Bureau
     ?lmandaat ^org:hasPost ?lbestuursorgaan.
     ?lbestuursorgaan mandaat:isTijdspecialisatieVan ?lbestuursorgaanInTijd.
     ?lbestuursorgaan lmb:heeftBestuursperiode ?bestuursperiode.
@@ -41,7 +41,4 @@ WHERE {
 
   FILTER (?mandataris != ?linkedMandataris)
   BIND (<http://data.lblod.info/id/concept/Bestuursperiode/96efb929-5d83-48fa-bfbb-b98dfb1180c7> AS ?bestuursperiode) # 2024 - heden
-  VALUES (?bfCode ?linkedBfCode) {
-    (bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000014 bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000017) # Schepen | Lid Vast Bureau
-  }
 }

--- a/config/migrations/2024/20241205154800-link-not-linked-mandatarissen-from-past-3.sparql
+++ b/config/migrations/2024/20241205154800-link-not-linked-mandatarissen-from-past-3.sparql
@@ -42,6 +42,6 @@ WHERE {
   FILTER (?mandataris != ?linkedMandataris)
   BIND (<http://data.lblod.info/id/concept/Bestuursperiode/96efb929-5d83-48fa-bfbb-b98dfb1180c7> AS ?bestuursperiode) # 2024 - heden
   VALUES (?bfCode ?linkedBfCode) {
-    (bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000011 bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000015) # Gemeenteraadslid | Lid RMV
+    (bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000014 bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000017) # Schepen | Lid Vast Bureau
   }
 }

--- a/config/migrations/2024/20241205154800-link-not-linked-mandatarissen-from-past-4.sparql
+++ b/config/migrations/2024/20241205154800-link-not-linked-mandatarissen-from-past-4.sparql
@@ -20,7 +20,7 @@ WHERE {
     OPTIONAL {
       ?mandataris mandaat:einde ?mandatarisEinde.
     }
-    ?mandaat org:role ?bfCode.
+    ?mandaat org:role bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000013. # Burgemeester
     ?mandaat ^org:hasPost ?bestuursorgaan.
     ?bestuursorgaan mandaat:isTijdspecialisatieVan ?bestuursorgaanInTijd.
     ?bestuursorgaan lmb:heeftBestuursperiode ?bestuursperiode.
@@ -33,7 +33,7 @@ WHERE {
     OPTIONAL {
       ?linkedMandataris mandaat:einde ?mandatarisEinde.
     }
-    ?lmandaat org:role ?linkedBfCode.
+    ?lmandaat org:role bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000018. # Voorzitter Vast Bureau
     ?lmandaat ^org:hasPost ?lbestuursorgaan.
     ?lbestuursorgaan mandaat:isTijdspecialisatieVan ?lbestuursorgaanInTijd.
     ?lbestuursorgaan lmb:heeftBestuursperiode ?bestuursperiode.
@@ -41,7 +41,4 @@ WHERE {
 
   FILTER (?mandataris != ?linkedMandataris)
   BIND (<http://data.lblod.info/id/concept/Bestuursperiode/96efb929-5d83-48fa-bfbb-b98dfb1180c7> AS ?bestuursperiode) # 2024 - heden
-  VALUES (?bfCode ?linkedBfCode) {
-    (bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000013 bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000018) # Burgemeester | Voorzitter Vast Bureau
-  }
 }

--- a/config/migrations/2024/20241205154800-link-not-linked-mandatarissen-from-past-4.sparql
+++ b/config/migrations/2024/20241205154800-link-not-linked-mandatarissen-from-past-4.sparql
@@ -42,6 +42,6 @@ WHERE {
   FILTER (?mandataris != ?linkedMandataris)
   BIND (<http://data.lblod.info/id/concept/Bestuursperiode/96efb929-5d83-48fa-bfbb-b98dfb1180c7> AS ?bestuursperiode) # 2024 - heden
   VALUES (?bfCode ?linkedBfCode) {
-    (bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000011 bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000015) # Gemeenteraadslid | Lid RMV
+    (bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000013 bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000018) # Burgemeester | Voorzitter Vast Bureau
   }
 }

--- a/config/migrations/2024/20241205154800-link-not-linked-mandatarissen-from-past-5.sparql
+++ b/config/migrations/2024/20241205154800-link-not-linked-mandatarissen-from-past-5.sparql
@@ -42,6 +42,6 @@ WHERE {
   FILTER (?mandataris != ?linkedMandataris)
   BIND (<http://data.lblod.info/id/concept/Bestuursperiode/96efb929-5d83-48fa-bfbb-b98dfb1180c7> AS ?bestuursperiode) # 2024 - heden
   VALUES (?bfCode ?linkedBfCode) {
-    (bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000011 bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000015) # Gemeenteraadslid | Lid RMV
+    (bestuursfunctieCode:7b038cc40bba10bec833ecfe6f15bc7a bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000018) # Aangewezen burgemeester | Voorzitter Vast Bureau
   }
 }

--- a/config/migrations/2024/20241205154800-link-not-linked-mandatarissen-from-past-5.sparql
+++ b/config/migrations/2024/20241205154800-link-not-linked-mandatarissen-from-past-5.sparql
@@ -20,7 +20,7 @@ WHERE {
     OPTIONAL {
       ?mandataris mandaat:einde ?mandatarisEinde.
     }
-    ?mandaat org:role ?bfCode.
+    ?mandaat org:role bestuursfunctieCode:7b038cc40bba10bec833ecfe6f15bc7a. # Aangewezen burgemeester
     ?mandaat ^org:hasPost ?bestuursorgaan.
     ?bestuursorgaan mandaat:isTijdspecialisatieVan ?bestuursorgaanInTijd.
     ?bestuursorgaan lmb:heeftBestuursperiode ?bestuursperiode.
@@ -33,7 +33,7 @@ WHERE {
     OPTIONAL {
       ?linkedMandataris mandaat:einde ?mandatarisEinde.
     }
-    ?lmandaat org:role ?linkedBfCode.
+    ?lmandaat org:role bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000018. # Voorzitter Vast Bureau
     ?lmandaat ^org:hasPost ?lbestuursorgaan.
     ?lbestuursorgaan mandaat:isTijdspecialisatieVan ?lbestuursorgaanInTijd.
     ?lbestuursorgaan lmb:heeftBestuursperiode ?bestuursperiode.
@@ -41,7 +41,4 @@ WHERE {
 
   FILTER (?mandataris != ?linkedMandataris)
   BIND (<http://data.lblod.info/id/concept/Bestuursperiode/96efb929-5d83-48fa-bfbb-b98dfb1180c7> AS ?bestuursperiode) # 2024 - heden
-  VALUES (?bfCode ?linkedBfCode) {
-    (bestuursfunctieCode:7b038cc40bba10bec833ecfe6f15bc7a bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000018) # Aangewezen burgemeester | Voorzitter Vast Bureau
-  }
 }

--- a/config/migrations/2024/20241205154800-link-not-linked-mandatarissen-from-past.sparql
+++ b/config/migrations/2024/20241205154800-link-not-linked-mandatarissen-from-past.sparql
@@ -37,15 +37,9 @@ WHERE {
     ?lmandaat ^org:hasPost ?lbestuursorgaan.
     ?lbestuursorgaan mandaat:isTijdspecialisatieVan ?lbestuursorgaanInTijd.
     ?lbestuursorgaan lmb:heeftBestuursperiode ?bestuursperiode.
-    }
-
-    FILTER NOT EXISTS {
-    GRAPH <http://mu.semte.ch/graphs/linkedInstances> {
-      { ?mandataris ext:linked ?linkedMandataris . } UNION { ?linkedMandataris ext:linked ?mandataris . }
-    }
   }
+  
   FILTER (?mandataris != ?linkedMandataris)
-
   BIND (<http://data.lblod.info/id/concept/Bestuursperiode/96efb929-5d83-48fa-bfbb-b98dfb1180c7> AS ?bestuursperiode) # 2024 - heden
   VALUES (?bfCode ?linkedBfCode) {
     (bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000011 bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000015) # Gemeenteraadslid | Lid RMV

--- a/config/migrations/2024/20241205154800-link-not-linked-mandatarissen-from-past.sparql
+++ b/config/migrations/2024/20241205154800-link-not-linked-mandatarissen-from-past.sparql
@@ -12,13 +12,11 @@ INSERT {
 }  
 WHERE {
   GRAPH ?g {
-    ?mandataris a mandaat:Mandataris.
     ?mandataris org:holds ?mandaat.
     ?mandataris mandaat:start ?mandatarisStart.
     ?mandataris mandaat:status ?mandatarisStatus.
     ?mandataris mandaat:isBestuurlijkeAliasVan ?persoon.
-    ?mandataris org:hasMembership ?membership.
-    ?membership org:organisation ?fractie.
+    ?mandataris org:hasMembership / org:organisation ?fractie.
     OPTIONAL {
       ?mandataris mandaat:einde ?mandatarisEinde.
     }
@@ -27,13 +25,11 @@ WHERE {
     ?bestuursorgaan mandaat:isTijdspecialisatieVan ?bestuursorgaanInTijd.
     ?bestuursorgaan lmb:heeftBestuursperiode ?bestuursperiode.
 
-    ?linkedMandataris a mandaat:Mandataris.
     ?linkedMandataris org:holds ?lmandaat.
     ?linkedMandataris mandaat:start ?mandatarisStart.
     ?linkedMandataris mandaat:status ?mandatarisStatus.
     ?linkedMandataris mandaat:isBestuurlijkeAliasVan ?persoon.
-    ?linkedMandataris org:hasMembership ?lmembership.
-    ?lmembership org:organisation ?fractie.
+    ?linkedMandataris org:hasMembership / org:organisation ?fractie.
     OPTIONAL {
       ?linkedMandataris mandaat:einde ?mandatarisEinde.
     }

--- a/config/migrations/2024/20241205154800-link-not-linked-mandatarissen-from-past.sparql
+++ b/config/migrations/2024/20241205154800-link-not-linked-mandatarissen-from-past.sparql
@@ -1,0 +1,61 @@
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
+PREFIX bestuursfunctieCode: <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/linkedInstances> {
+    ?mandataris ext:linked ?linkedMandataris.
+  }
+}  
+WHERE {
+  GRAPH ?g {
+    ?mandataris a mandaat:Mandataris.
+    ?mandataris org:holds ?mandaat.
+    ?mandataris mandaat:start ?mandatarisStart.
+    ?mandataris mandaat:status ?mandatarisStatus.
+    ?mandataris mandaat:isBestuurlijkeAliasVan ?persoon.
+    ?mandataris org:hasMembership ?membership.
+    ?membership org:organisation ?fractie.
+    OPTIONAL {
+      ?mandataris mandaat:einde ?mandatarisEinde.
+    }
+    ?mandaat org:role ?bfCode.
+    ?mandaat ^org:hasPost ?bestuursorgaan.
+    ?bestuursorgaan mandaat:isTijdspecialisatieVan ?bestuursorgaanInTijd.
+    ?bestuursorgaan lmb:heeftBestuursperiode ?bestuursperiode.
+
+    ?linkedMandataris a mandaat:Mandataris.
+    ?linkedMandataris org:holds ?lmandaat.
+    ?linkedMandataris mandaat:start ?mandatarisStart.
+    ?linkedMandataris mandaat:status ?mandatarisStatus.
+    ?linkedMandataris mandaat:isBestuurlijkeAliasVan ?persoon.
+    ?linkedMandataris org:hasMembership ?lmembership.
+    ?lmembership org:organisation ?fractie.
+    OPTIONAL {
+      ?linkedMandataris mandaat:einde ?mandatarisEinde.
+    }
+    ?lmandaat org:role ?linkedBfCode.
+    ?lmandaat ^org:hasPost ?lbestuursorgaan.
+    ?lbestuursorgaan mandaat:isTijdspecialisatieVan ?lbestuursorgaanInTijd.
+    ?lbestuursorgaan lmb:heeftBestuursperiode ?bestuursperiode.
+    }
+
+    FILTER NOT EXISTS {
+    GRAPH <http://mu.semte.ch/graphs/linkedInstances> {
+      { ?mandataris ext:linked ?linkedMandataris . } UNION { ?linkedMandataris ext:linked ?mandataris . }
+    }
+  }
+  FILTER (?mandataris != ?linkedMandataris)
+
+  BIND (<http://data.lblod.info/id/concept/Bestuursperiode/96efb929-5d83-48fa-bfbb-b98dfb1180c7> AS ?bestuursperiode) # 2024 - heden
+  VALUES (?bfCode ?linkedBfCode) {
+    (bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000011 bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000015) # Gemeenteraadslid | Lid RMV
+    (bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000012 bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000016) # Voorzitter Gemeenteraad | Voorzitter RMV
+    (bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000014 bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000017) # Schepen | Lid Vast Bureau
+    (bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000013 bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000018) # Burgemeester | Voorzitter Vast Bureau
+    (bestuursfunctieCode:7b038cc40bba10bec833ecfe6f15bc7a bestuursfunctieCode:5ab0e9b8a3b2ca7c5e000018) # Aangewezen burgemeester | Voorzitter Vast Bureau
+  }
+}


### PR DESCRIPTION
## Description

Its possible that some mandatarissen are not linked in the current bestuursperiode as this is something we did later. We have written a insert query that will link the mandatarissen that should to each other.

## How to test

Run the query as a `SELECT`  without the `FILTER NOT EXISTS`  (bnut with the union) and see the `COUNT` of what it returns (136 +-). After running that one run the query from this PR. This should make the count of the first query zero.

NOTE: this query can take some time
