### PR TITLE
Ben/lmb 1149 sync vendor access

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -112,3 +112,5 @@ services:
       EMAIL_CRON_PATTERN: "* * * * *" # Every minute
       CRON_FREQUENCY,: "* * * * *"
       LOG_ERRORS: true
+  vendor-management-consumer:
+    restart: "no"

--- a/docker-compose.mac.yml
+++ b/docker-compose.mac.yml
@@ -25,3 +25,5 @@ services:
     platform: linux/amd64
   cache:
     platform: linux/amd64
+  vendor-management-consumer:
+    platform: linux/amd64

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -276,3 +276,20 @@ services:
     volumes:
       - ./data/mail:/share
     logging: *default-logging
+  vendor-management-consumer:
+    image: lblod/delta-consumer:latest
+    environment:
+      DCR_SYNC_BASE_URL: "https://dev.loket.lblod.info/"
+      DCR_SYNC_LOGIN_ENDPOINT: 'https://dev.loket.lblod.info/sync/vendor-management/login' # Add DCR_SECRET_KEY in docker-compose.override.yml
+      DCR_SERVICE_NAME: "vendor-management-consumer"
+      DCR_SYNC_FILES_PATH: "/sync/vendor-management/files"
+      DCR_SYNC_DATASET_SUBJECT: "http://data.lblod.info/datasets/delta-producer/dumps/VendorManagementCacheGraphDump"
+      DCR_INITIAL_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/initialSync/vendor-management"
+      DCR_JOB_CREATOR_URI: "http://data.lblod.info/services/id/vendor-management-consumer"
+      DCR_DISABLE_INITIAL_SYNC: "false"
+      DCR_KEEP_DELTA_FILES: "true"
+      DCR_DELTA_FILE_FOLDER: "/consumer-files"
+      DCR_DELTA_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/VendorManagementFileSyncing"
+      INGEST_GRAPH: "http://mu.semte.ch/graphs/automatic-submission"
+    restart: always
+    logging: *default-logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -277,7 +277,7 @@ services:
       - ./data/mail:/share
     logging: *default-logging
   vendor-management-consumer:
-    image: lblod/delta-consumer:latest
+    image: lblod/delta-consumer:0.0.26
     environment:
       DCR_SERVICE_NAME: "vendor-management-consumer"
       DCR_SYNC_BASE_URL: "https://dev.loket.lblod.info/"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -279,17 +279,18 @@ services:
   vendor-management-consumer:
     image: lblod/delta-consumer:latest
     environment:
-      DCR_SYNC_BASE_URL: "https://dev.loket.lblod.info/"
-      DCR_SYNC_LOGIN_ENDPOINT: 'https://dev.loket.lblod.info/sync/vendor-management/login' # Add DCR_SECRET_KEY in docker-compose.override.yml
       DCR_SERVICE_NAME: "vendor-management-consumer"
+      DCR_SYNC_BASE_URL: "https://dev.loket.lblod.info/"
       DCR_SYNC_FILES_PATH: "/sync/vendor-management/files"
+      DCR_JOB_CREATOR_URI: "http://data.lblod.info/services/id/vendor-management-consumer"
       DCR_SYNC_DATASET_SUBJECT: "http://data.lblod.info/datasets/delta-producer/dumps/VendorManagementCacheGraphDump"
       DCR_INITIAL_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/initialSync/vendor-management"
-      DCR_JOB_CREATOR_URI: "http://data.lblod.info/services/id/vendor-management-consumer"
-      DCR_DISABLE_INITIAL_SYNC: "false"
-      DCR_KEEP_DELTA_FILES: "true"
-      DCR_DELTA_FILE_FOLDER: "/consumer-files"
       DCR_DELTA_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/VendorManagementFileSyncing"
       INGEST_GRAPH: "http://mu.semte.ch/graphs/automatic-submission"
+      DCR_DISABLE_INITIAL_SYNC: "true"
+      DCR_KEEP_DELTA_FILES: "true"
+      DCR_DELTA_FILE_FOLDER: "/consumer-files"
+      DCR_CRON_PATTERN_DELTA_SYNC: "0 20 0 * *" # Every day at 8 pm
+      DCR_SYNC_LOGIN_ENDPOINT: 'https://dev.loket.lblod.info/sync/vendor-management/login' # Add DCR_SECRET_KEY in docker-compose.override.yml
     restart: always
     logging: *default-logging


### PR DESCRIPTION
## Description

Add sync with loket for vendor management updates.

## How to test

Add the following in docker.compose.override.yml, with DCR key! Ask me for it.
```
  vendor-management-consumer:
    environment:
      BATCH_SIZE: "500"
      DCR_SYNC_BASE_URL: https://loket.lokaalbestuur.vlaanderen.be/
      DCR_DISABLE_INITIAL_SYNC: 'true' # Switch to false when system is ready to consume data
      DCR_SYNC_LOGIN_ENDPOINT: 'https://loket.lokaalbestuur.vlaanderen.be/sync/vendor-management/login'
      DCR_CRON_PATTERN_DELTA_SYNC: '0 * * * * *"
      DCR_SECRET_KEY: 'key'
```

Then spin up virtuoso.
Then spin up the rest.
After you migrations are finished, change `DCR_DISABEL_INITIAL_SYNC` to false and restart the vendor-management-consumer
Check the logs to see an initial sync happens and that after this there are no more updates.
If you check vendor acces for e.g. Pajottegem, this should now have a vendor which it did not before.
