### PR TITLE
Lmb 1180 | fix end date organen in tijd 2024-12-02

### DIFF
--- a/config/migrations/2024/20241211095143-update-end-date-of-bestuursorganen.sparql
+++ b/config/migrations/2024/20241211095143-update-end-date-of-bestuursorganen.sparql
@@ -1,15 +1,18 @@
 PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
 
 DELETE {
   GRAPH ?g { 
     ?boit mandaat:bindingEinde ?einde.
+    ?boit dcterms:modified ?modified.
   }
 }
 INSERT {
   GRAPH ?g { 
     ?boit mandaat:bindingEinde """2024-12-02"""^^xsd:date.
+    ?boit dcterms:modified ?now.
   }
 }
 WHERE {
@@ -17,6 +20,10 @@ WHERE {
     ?boit mandaat:isTijdspecialisatieVan ?bo.
     ?boit mandaat:bindingEinde ?einde.
     ?boit mandaat:bindingStart """2019-01-01"""^^xsd:date.
+    OPTIONAL {
+      ?boit dcterms:modified ?modified.
+    }
   }
   ?g ext:ownedBy ?something.
+  BIND(NOW() as ?now)
 } 

--- a/config/migrations/2024/20241211095143-update-end-date-of-bestuursorganen.sparql
+++ b/config/migrations/2024/20241211095143-update-end-date-of-bestuursorganen.sparql
@@ -1,0 +1,22 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+DELETE {
+  GRAPH ?g { 
+    ?boit mandaat:bindingEinde ?einde.
+  }
+}
+INSERT {
+  GRAPH ?g { 
+    ?boit mandaat:bindingEinde """2024-12-02"""^^xsd:date.
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?boit mandaat:isTijdspecialisatieVan ?bo.
+    ?boit mandaat:bindingEinde ?einde.
+    ?boit mandaat:bindingStart """2019-01-01"""^^xsd:date.
+  }
+  ?g ext:ownedBy ?something.
+} 


### PR DESCRIPTION
## Description

We got email from remicon that they expect a different end date 2025-01-01 is wrong => change it to 2024-12-2

## How to test

Migration runs on prod data. There test query should only return one entree

```
#+begin_src sparql :url "http://localhost:8890/sparql" :format text/csv
  SELECT ?orgaanTijdspecialisatie ?orgaanTijdspecialisatieEinde ?orgaanTijdspecialisatieStart
   WHERE {
     GRAPH ?g {
     BIND ("""2024-12-09"""^^<http://www.w3.org/2001/XMLSchema#date> AS ?vergaderingDatum)
     ?orgaanTijdspecialisatie <http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan> <http://data.lblod.info/id/bestuursorganen/888aa938e198341244135e14d2faaf7efdedb126c4e245c3c4db6caaf87d71aa> ;
          <http://data.vlaanderen.be/ns/mandaat#bindingStart> ?orgaanTijdspecialisatieStart.
}
     OPTIONAL {?orgaanTijdspecialisatie <http://data.vlaanderen.be/ns/mandaat#bindingEinde> ?orgaanTijdspecialisatieEinde .}
     FILTER (
             ( NOT EXISTS {
               ?orgaanTijdspecialisatie <http://data.vlaanderen.be/ns/mandaat#bindingEinde> ?orgaanTijdspecialisatieEinde
             }
              || ?orgaanTijdspecialisatieEinde > ?vergaderingDatum
              )
             && ?orgaanTijdspecialisatieStart <= ?vergaderingDatum
             )
   }
#+end_src

| orgaanTijdspecialisatie                                                                                    | orgaanTijdspecialisatieEinde | orgaanTijdspecialisatieStart |
|------------------------------------------------------------------------------------------------------------+------------------------------+------------------------------|
| http://data.lblod.info/id/bestuursorganen/9d25b1c421e0070e604389b4cea24817627621aa87c8be4bd4369a9fc79e802b |                              | 2024-12-02T00:00:00          |

```

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/180
