### PR TITLE
LMB-1187 fixed cron pattern delta consumer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -309,7 +309,7 @@ services:
       DCR_DISABLE_INITIAL_SYNC: "true"
       DCR_KEEP_DELTA_FILES: "true"
       DCR_DELTA_FILE_FOLDER: "/consumer-files"
-      DCR_CRON_PATTERN_DELTA_SYNC: "0 20 0 * *" # Every day at 8 pm
+      DCR_CRON_PATTERN_DELTA_SYNC: "0 20 * * *" # Every day at 8 pm
       DCR_SYNC_LOGIN_ENDPOINT: "https://dev.loket.lblod.info/sync/vendor-management/login" # Add DCR_SECRET_KEY in docker-compose.override.yml
     restart: always
     logging: *default-logging


### PR DESCRIPTION
## Description

Fixed a cron pattern in the delta consumer. This service was down on dev and test. 
It is fine on prod, because there the cron pattern is overwritten in the `docker-compose.override.yml`

## How to test

If you ran the delta-consumer before, without override, the service would crash, because it is not a valid cron pattern. Now with this PR it should be fine.