### PR TITLE
clean up duplicate memberships

### DIFF
--- a/config/migrations/2024/20241216140500-clean-up-duplicate-membershipts.sparql
+++ b/config/migrations/2024/20241216140500-clean-up-duplicate-membershipts.sparql
@@ -1,0 +1,34 @@
+  PREFIX astreams: <http://www.w3.org/ns/activitystreams#>
+  PREFIX dct: <http://purl.org/dc/terms/>
+  PREFIX org: <http://www.w3.org/ns/org#>
+  DELETE {
+    GRAPH ?g {
+      ?lidmaatschap ?p ?o.
+      ?oo ?pp ?lidmaatschap.
+    }
+  }
+  INSERT {
+    GRAPH ?g {
+      ?lidmaatschap a astreams:Tombstone.
+      ?lidmaatschap dct:modified ?now.
+      ?lidmaatschap astreams:deleted ?now.
+      ?lidmaatschap astreams:formerType org:Membership .
+    }
+  } WHERE {
+    VALUES ?lidmaatschap {
+      # Beerse, winner: http://data.lblod.info/id/lidmaatschappen/3d1a3f8f-2567-47a0-8065-8c8908bfc73d
+      <http://data.lblod.info/id/lidmaatschappen/f4d8dacc-ed02-4afe-8d5d-fa97fdc10a91>
+      <http://data.lblod.info/id/lidmaatschappen/1c5566a2-7b03-4a11-a75d-8b6c60d913e3>
+      # Dilbeek, winner: http://data.lblod.info/id/lidmaatschappen/5C52EC49D5BECA000B000169
+      <http://data.lblod.info/id/lidmaatschappen/6f639a70-22f7-4c6c-910e-ee8e22237c93>
+      # Riemst, winner: http://data.lblod.info/id/lidmaatschappen/67592e6b-0e54-4fed-b76c-5f2e8eb23d72
+      <http://data.lblod.info/id/lidmaatschappen/68edf0f9-76f8-4b6c-8edc-0cabaf32567d>
+      <http://data.lblod.info/id/lidmaatschappen/17db8b76-0cd5-491d-8ef9-a46fdc56ed74>
+    }
+
+    GRAPH ?g {
+      ?lidmaatschap ?p ?o.
+      ?oo ?pp ?lidmaatschap.
+    }
+    BIND(NOW() AS ?now)
+  }


### PR DESCRIPTION
## Description

we got some duplicate memberships from loket it seems. This removes them.
## How to test

go to riemst, see that dirk doesn't have a cd&v fractie linked