### PR TITLE
fix duplicate person uri

### DIFF
--- a/config/migrations/2024/20250109090600-fix-duplicate-person-uri.sparql
+++ b/config/migrations/2024/20250109090600-fix-duplicate-person-uri.sparql
@@ -1,0 +1,39 @@
+  PREFIX dct: <http://purl.org/dc/terms/>
+  PREFIX owl: <http://www.w3.org/2002/07/owl#>
+  DELETE {
+    GRAPH ?g {
+      <http://data.lblod.info/id/personen/6630925FF0F686D7CD7EF968> dct:modified ?old.
+      <http://data.lblod.info/id/personen/6630925FF0F686D7CD7EF968> ?p ?o.
+    }
+    GRAPH ?h {
+      ?oo ?pp <http://data.lblod.info/id/personen/6630925FF0F686D7CD7EF968> .
+      ?oo dct:modified ?oldOther.
+    }
+  }
+  INSERT {
+    GRAPH ?g {
+      <http://data.lblod.info/id/personen/0bd64b06-c6ef-41e7-97ea-45bf1b4cef63> ?p ?o.
+      <http://data.lblod.info/id/personen/6630925FF0F686D7CD7EF968> owl:sameAs <http://data.lblod.info/id/personen/6630925FF0F686D7CD7EF968>.
+      <http://data.lblod.info/id/personen/0bd64b06-c6ef-41e7-97ea-45bf1b4cef63> dct:modified ?now.
+    }
+    GRAPH ?h {
+      ?oo ?pp <http://data.lblod.info/id/personen/0bd64b06-c6ef-41e7-97ea-45bf1b4cef63> .
+      ?oo dct:modified ?now.
+    }
+  }WHERE {
+    GRAPH ?g {
+      <http://data.lblod.info/id/personen/6630925FF0F686D7CD7EF968> ?p ?o.
+      OPTIONAL {
+        <http://data.lblod.info/id/personen/6630925FF0F686D7CD7EF968> dct:modified ?old.
+      }
+    }
+    OPTIONAL {
+      GRAPH ?h {
+        ?oo ?pp <http://data.lblod.info/id/personen/6630925FF0F686D7CD7EF968>.
+        OPTIONAL {
+          ?oo dct:modified ?oldOther.
+        }
+      }
+    }
+    BIND(NOW() AS ?now)
+  }

--- a/config/migrations/2024/20250109090600-fix-duplicate-person-uri.sparql
+++ b/config/migrations/2024/20250109090600-fix-duplicate-person-uri.sparql
@@ -23,6 +23,7 @@
   }WHERE {
     GRAPH ?g {
       <http://data.lblod.info/id/personen/6630925FF0F686D7CD7EF968> ?p ?o.
+      FILTER(?p NOT IN (<http://data.vlaanderen.be/ns/persoon#gebruikteVoornaam>, <http://xmlns.com/foaf/0.1/familyName>))
       OPTIONAL {
         <http://data.lblod.info/id/personen/6630925FF0F686D7CD7EF968> dct:modified ?old.
       }


### PR DESCRIPTION
## Description

Loket had two person uris for this person, one of them had a space in their first name. We merge them and keep a sameAs between them.

## How to test

Cevi ran this query (minor modifications):

```
  PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#> 

  PREFIX org: <http://www.w3.org/ns/org#> 

  PREFIX skos: <http://www.w3.org/2004/02/skos/core#> 

  PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#> 

  PREFIX foaf: <http://xmlns.com/foaf/0.1/> 

  SELECT DISTINCT ?persoonUri ?achternaam ?naam

  WHERE {{ 

    VALUES ?achternaam {
       "Van Loo"
      }

  ?orgaan mandaat:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7> ; 

  org:hasPost ?mandaat . 

  ?mandataris org:holds ?mandaat ; 

  mandaat:isBestuurlijkeAliasVan ?persoonUri . 

  ?persoonUri foaf:familyName ?achternaam ; 

  persoon:gebruikteVoornaam ?naam . 

  }} 

  ORDER BY ?achternaam ?naam 
```
should no longer give duplicate results