### PR TITLE
complex paths in library fields

### DIFF
--- a/config/cl-authorization/config.lisp
+++ b/config/cl-authorization/config.lisp
@@ -108,6 +108,7 @@
   ("contacthub:AgentInPositie" -> _)
   ("mandaat:Fractie" -> _)
   ("persoon:Geboorte" -> _)
+  ("persoon:Overlijden" -> _)
   ("org:Membership" -> _)
   ("besluit:Besluit" -> _)
   ("besluit:Artikel" -> _)

--- a/config/form-content/mandataris-edit/form.ttl
+++ b/config/form-content/mandataris-edit/form.ttl
@@ -132,14 +132,14 @@ ext:editMandatarisPG
 
 ext:mandatarisG a form:Generator;
   form:prototype [
-    form:shape [
-        a mandaat:Mandataris;
-        org:hasMembership [
-        a org:Membership
-      ]
-    ]
+    form:shape ext:mandatarisShape
   ];
   form:dataGenerator form:addMuUuid.
+
+ext:mandatarisShape a mandaat:Mandataris;
+  org:hasMembership [
+    a org:Membership
+  ].
 
   ext:membershipUriG a form:UriGenerator;
   form:prefix "http://data.lblod.info/id/lidmaatschappen/";

--- a/config/form-content/persoon/form.ttl
+++ b/config/form-content/persoon/form.ttl
@@ -124,17 +124,17 @@ ext:possibleDuplicateF
 
 ext:personG a form:Generator;
   form:prototype [
-    form:shape [
-      a person:Person;
-      persoon:heeftGeboorte [
-        a persoon:Geboorte
-      ];
-      adms:identifier [
-        a adms:Identifier
-      ]
-    ]
+    form:shape ext:personShape
   ];
   form:dataGenerator form:addMuUuid.
+
+  ext:personShape a person:Person;
+      persoon:heeftGeboorte [
+        a persoon:Geboorte
+      ] ;
+      adms:identifier [
+        a adms:Identifier
+      ] .
 
 ext:geboorteUriG a form:UriGenerator;
   form:prefix "http://data.lblod.info/id/geboortes/";

--- a/config/migrations/2025/20250106141000-create-form-field-library.sparql
+++ b/config/migrations/2025/20250106141000-create-form-field-library.sparql
@@ -1,0 +1,45 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX form: <http://lblod.data.gift/vocabularies/forms/>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/lmb/form-library-entries/095d1329-a9fa-4d72-8c49-eb52aaf893de> a ext:FormLibraryEntry ;
+     mu:uuid "095d1329-a9fa-4d72-8c49-eb52aaf893de" ;
+     sh:name "Verblijfsadres" ;
+     form:displayType <http://lblod.data.gift/display-types/lmb/custom-address-input> ;
+     sh:path <https://data.vlaanderen.be/ns/persoon#verblijfsadres> ;
+     sh:order 900 .
+
+    <http://data.lblod.info/id/lmb/form-library-entries/31004e04-1b1a-4fda-80ae-612d67a14b5e> a ext:FormLibraryEntry ;
+     mu:uuid "31004e04-1b1a-4fda-80ae-612d67a14b5e" ;
+     sh:name "Geboorteplaats" ;
+     form:displayType <http://lblod.data.gift/display-types/lmb/custom-string-input> ;
+     sh:path <http://www.w3.org/ns/person#placeOfBirth> ;
+     sh:order 1000 .
+
+    <http://data.lblod.info/id/lmb/form-library-entries/0bdd360b-c6e5-46d9-9a31-8645a4c5774c> a ext:FormLibraryEntry ;
+     mu:uuid "0bdd360b-c6e5-46d9-9a31-8645a4c5774c" ;
+     sh:name "Sterfdatum" ;
+     form:displayType <http://lblod.data.gift/display-types/lmb/custom-date-input> ;
+     sh:path <http://data.lblod.info/id/lmb/paths/574867d1-3422-41a9-8648-34dc2c443204> ;
+     ext:needsShape <http://data.lblod.info/id/lmb/shapes/d56503fc-96d4-49fc-8425-e36db36fd172> ;
+     ext:needsGenerator <http://data.lblod.info/id/lmb/generators/3afc0fad-e475-4696-ae50-3627fed41cf8> ;
+     sh:order 1000 .
+
+    <http://data.lblod.info/id/lmb/paths/574867d1-3422-41a9-8648-34dc2c443204> rdf:first <http://data.vlaanderen.be/ns/persoon#heeftOverlijden> ;
+      rdf:rest <http://data.lblod.info/id/lmb/paths/0c65e9c8-0910-490a-96e7-19b71290b91a> .
+    <http://data.lblod.info/id/lmb/paths/0c65e9c8-0910-490a-96e7-19b71290b91a> rdf:first <http://data.vlaanderen.be/ns/persoon#datum> ;
+      rdf:rest rdf:nil .
+
+    <http://data.lblod.info/id/lmb/shapes/d56503fc-96d4-49fc-8425-e36db36fd172> <http://data.vlaanderen.be/ns/persoon#heeftOverlijden> <http://data.lblod.info/id/lmb/shapes/048663a1-6b73-4346-8267-0f40e0dff9f4> .
+
+    <http://data.lblod.info/id/lmb/shapes/048663a1-6b73-4346-8267-0f40e0dff9f4> a <http://data.vlaanderen.be/ns/persoon#Overlijden> .
+
+    <http://data.lblod.info/id/lmb/generators/3afc0fad-e475-4696-ae50-3627fed41cf8> a form:UriGenerator;
+      form:prefix "http://data.lblod.info/id/overlijden/";
+      form:forType persoon:Overlijden.
+  }
+}

--- a/config/migrations/2025/20250107114000-add-display-types.sparql
+++ b/config/migrations/2025/20250107114000-add-display-types.sparql
@@ -1,0 +1,37 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.data.gift/concept-schemes/lmb-custom-display-types> a skos:ConceptScheme ;
+     mu:uuid "9a862e11-1e1a-44b5-b8bd-e1d7d73c82da" ;
+     skos:prefLabel "LMB custom display types" .
+
+    <http://lblod.data.gift/display-types/lmb/custom-string-input> a ext:DisplayType ;
+     mu:uuid "220427c5-65c7-4be6-b84a-fc7401b465ec" ;
+     skos:prefLabel "Tekst (kort)" .
+
+    <http://lblod.data.gift/display-types/lmb/custom-text-input> a ext:DisplayType ;
+     mu:uuid "23ff0395-2a32-4cd2-9fbb-67c262f61e03" ;
+     skos:prefLabel "Tekst (lang)" .
+
+    <http://lblod.data.gift/display-types/lmb/custom-address-input> a ext:DisplayType ;
+     mu:uuid "b1ec9b19-68de-4d51-b4e0-b303b881f567" ;
+     skos:prefLabel "Adres" .
+
+    <http://lblod.data.gift/display-types/lmb/custom-date-input> a ext:DisplayType ;
+     mu:uuid "fefdc16e-38b9-4c1d-89be-c86ea57795d5" ;
+     skos:prefLabel "Datum" .
+
+    <http://lblod.data.gift/display-types/lmb/custom-number-input> a ext:DisplayType ;
+     mu:uuid "961f1670-8028-407d-a324-40113f413826" ;
+     skos:prefLabel "Getal" .
+
+    <http://lblod.data.gift/display-types/lmb/custom-string-input> skos:inScheme <http://lblod.data.gift/concept-schemes/lmb-custom-display-types> .
+    <http://lblod.data.gift/display-types/lmb/custom-text-input> skos:inScheme <http://lblod.data.gift/concept-schemes/lmb-custom-display-types> .
+    <http://lblod.data.gift/display-types/lmb/custom-address-input> skos:inScheme <http://lblod.data.gift/concept-schemes/lmb-custom-display-types> .
+    <http://lblod.data.gift/display-types/lmb/custom-date-input> skos:inScheme <http://lblod.data.gift/concept-schemes/lmb-custom-display-types> .
+    <http://lblod.data.gift/display-types/lmb/custom-number-input> skos:inScheme <http://lblod.data.gift/concept-schemes/lmb-custom-display-types> .
+  }
+}

--- a/config/resources/external-mandaat.lisp
+++ b/config/resources/external-mandaat.lisp
@@ -73,8 +73,8 @@
 (define-resource mandataris ()
   :class (s-prefix "mandaat:Mandataris")
   :properties `((:rangorde :string ,(s-prefix "mandaat:rangorde"))
-                (:start :datetime ,(s-prefix "mandaat:start"))
-                (:einde :datetime ,(s-prefix "mandaat:einde"))
+                (:start :date ,(s-prefix "mandaat:start"))
+                (:einde :date ,(s-prefix "mandaat:einde"))
                 (:datum-eedaflegging :datetime ,(s-prefix "ext:datumEedaflegging"))
                 (:datum-ministrieel-besluit :datetime ,(s-prefix "ext:datumMinistrieelBesluit"))
                 (:generated-from :uri-set ,(s-prefix "ext:generatedFrom")) ;;if it e.g. comes from gelinkt-notuleren


### PR DESCRIPTION
## Description

Allow complex paths in library fields. Example: datum van overlijden
## How to test

Add the the field to a form, e.g. the correct mistakes form of a mandataris. See that the generators do their work and that the field is added along the path persoon:heeftOverlijden / persoon:datum

## Links to other PR's

- https://github.com/lblod/form-content-service/pull/67