### PR TITLE
fix name cd&v tessenderlo ham

### DIFF
--- a/config/migrations/2025/20250113160300-fix-cdnv-tesssenderlo-ham.sparql
+++ b/config/migrations/2025/20250113160300-fix-cdnv-tesssenderlo-ham.sparql
@@ -1,0 +1,30 @@
+PREFIX dct: <http://purl.org/dc/terms/>
+  DELETE {
+    GRAPH ?g {
+      <http://data.lblod.info/id/kandidatenlijsten/b52fd081-36bf-4436-98c8-92d80e90cdb2> <http://www.w3.org/2004/02/skos/core#prefLabel> ?oldKieslijstLabel.
+      <http://data.lblod.info/id/kandidatenlijsten/b52fd081-36bf-4436-98c8-92d80e90cdb2> dct:modified ?oldKieslijstModified.
+      <http://data.lblod.info/id/fracties/67572230E7EE8C335E7E4986> <https://www.w3.org/ns/regorg#legalName> ?oldFractieLabel.
+      <http://data.lblod.info/id/fracties/67572230E7EE8C335E7E4986> dct:modified ?oldFractieModified.
+    }
+  }
+  INSERT {
+    GRAPH ?g {
+      <http://data.lblod.info/id/kandidatenlijsten/b52fd081-36bf-4436-98c8-92d80e90cdb2> <http://www.w3.org/2004/02/skos/core#prefLabel> "cd&v Tessenderlo-Ham".
+      <http://data.lblod.info/id/kandidatenlijsten/b52fd081-36bf-4436-98c8-92d80e90cdb2> dct:modified ?now.
+      <http://data.lblod.info/id/fracties/67572230E7EE8C335E7E4986> <https://www.w3.org/ns/regorg#legalName> "cd&v Tessenderlo-Ham".
+      <http://data.lblod.info/id/fracties/67572230E7EE8C335E7E4986> dct:modified ?now.
+    }
+  }
+  WHERE {
+    GRAPH ?g {
+      <http://data.lblod.info/id/kandidatenlijsten/b52fd081-36bf-4436-98c8-92d80e90cdb2> <http://www.w3.org/2004/02/skos/core#prefLabel> ?oldKieslijstLabel.
+      OPTIONAL {
+        <http://data.lblod.info/id/kandidatenlijsten/b52fd081-36bf-4436-98c8-92d80e90cdb2> dct:modified ?oldKieslijstModified.
+      }
+      <http://data.lblod.info/id/fracties/67572230E7EE8C335E7E4986> <https://www.w3.org/ns/regorg#legalName> ?oldFractieLabel.
+      OPTIONAL {
+        <http://data.lblod.info/id/fracties/67572230E7EE8C335E7E4986> dct:modified ?oldFractieModified.
+      }
+    }
+    BIND(NOW() AS ?now)
+  }

--- a/config/migrations/2025/20250113160300-fix-cdnv-tesssenderlo-ham.sparql
+++ b/config/migrations/2025/20250113160300-fix-cdnv-tesssenderlo-ham.sparql
@@ -3,6 +3,8 @@ PREFIX dct: <http://purl.org/dc/terms/>
     GRAPH ?g {
       <http://data.lblod.info/id/kandidatenlijsten/b52fd081-36bf-4436-98c8-92d80e90cdb2> <http://www.w3.org/2004/02/skos/core#prefLabel> ?oldKieslijstLabel.
       <http://data.lblod.info/id/kandidatenlijsten/b52fd081-36bf-4436-98c8-92d80e90cdb2> dct:modified ?oldKieslijstModified.
+    }
+    GRAPH ?h {
       <http://data.lblod.info/id/fracties/67572230E7EE8C335E7E4986> <https://www.w3.org/ns/regorg#legalName> ?oldFractieLabel.
       <http://data.lblod.info/id/fracties/67572230E7EE8C335E7E4986> dct:modified ?oldFractieModified.
     }
@@ -11,6 +13,8 @@ PREFIX dct: <http://purl.org/dc/terms/>
     GRAPH ?g {
       <http://data.lblod.info/id/kandidatenlijsten/b52fd081-36bf-4436-98c8-92d80e90cdb2> <http://www.w3.org/2004/02/skos/core#prefLabel> "cd&v Tessenderlo-Ham".
       <http://data.lblod.info/id/kandidatenlijsten/b52fd081-36bf-4436-98c8-92d80e90cdb2> dct:modified ?now.
+    }
+    GRAPH ?h {
       <http://data.lblod.info/id/fracties/67572230E7EE8C335E7E4986> <https://www.w3.org/ns/regorg#legalName> "cd&v Tessenderlo-Ham".
       <http://data.lblod.info/id/fracties/67572230E7EE8C335E7E4986> dct:modified ?now.
     }
@@ -21,6 +25,8 @@ PREFIX dct: <http://purl.org/dc/terms/>
       OPTIONAL {
         <http://data.lblod.info/id/kandidatenlijsten/b52fd081-36bf-4436-98c8-92d80e90cdb2> dct:modified ?oldKieslijstModified.
       }
+    }
+    GRAPH ?h {
       <http://data.lblod.info/id/fracties/67572230E7EE8C335E7E4986> <https://www.w3.org/ns/regorg#legalName> ?oldFractieLabel.
       OPTIONAL {
         <http://data.lblod.info/id/fracties/67572230E7EE8C335E7E4986> dct:modified ?oldFractieModified.


### PR DESCRIPTION
## Description

fix name cd&v tessenderlo ham
## How to test

run this and restart resources and cache, see that the name of cd&v tessenderlo ham was updated from cd&v ham