### PR TITLE
lmb-1292 | Vast Bureau and RMW end state is effectief

### DIFF
--- a/config/migrations/2025/20250116140000-publication-status-bekrachtigd-toeffectief-for-VB-RMW.sparql
+++ b/config/migrations/2025/20250116140000-publication-status-bekrachtigd-toeffectief-for-VB-RMW.sparql
@@ -1,0 +1,35 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+
+DELETE {
+  GRAPH ?g {
+    ?mandataris lmb:hasPublicationStatus <http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/9d8fd14d-95d0-4f5e-b3a5-a56a126227b6> . # Bekrachtigd
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?mandataris lmb:hasPublicationStatus <http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/d3b12468-3720-4cb0-95b4-6aa2996ab188> . # Effectief
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?mandataris org:holds / ^org:hasPost ?boi .
+    ?mandataris lmb:hasPublicationStatus <http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/9d8fd14d-95d0-4f5e-b3a5-a56a126227b6> . # Bekrachtigd
+
+    ?boi lmb:heeftBestuursperiode ?bestuursperiode .
+    FILTER(?bestuursperiode IN(
+      <http://data.lblod.info/id/concept/Bestuursperiode/a2b977a3-ce68-4e42-80a6-4397f66fc5ca>, # 2019 - 2024
+      <http://data.lblod.info/id/concept/Bestuursperiode/96efb929-5d83-48fa-bfbb-b98dfb1180c7> # 2024 - heden
+    ))
+
+    ?boi mandaat:isTijdspecialisatieVan / besluit:classificatie ?classificatieCode .
+    FILTER(?classificatieCode IN(
+      <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000007>, # RMW
+      <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000008> # Vast Bureau
+    ))
+  }
+  ?g ext:ownedBy ?something .
+}


### PR DESCRIPTION
## Description

The end publication status of a mandataris in Vast Bureau or RMW is effectie. Created a migration to set all these statusses to effectief instead of bekrachtigd.

## How to test

- Go to Arendonk OCMW
- Bestuursorgaan RMW (you should see mandatarissen with pub status bekrachtigd)
- Run the migration and these should be effectief now

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/461
