### PR TITLE
lmb-1055 | escape all "user" input date in the ttl

### DIFF
--- a/config/ldes-delta-pusher/handle-decision-type.ts
+++ b/config/ldes-delta-pusher/handle-decision-type.ts
@@ -1,5 +1,6 @@
 import { Changeset } from "../types";
 import { querySudo } from "@lblod/mu-auth-sudo";
+import { sparqlEscapeUri } from "mu";
 
 import { publishInterestingSubjects } from "./handle-types-util";
 import { InterestingSubject } from "./publisher";
@@ -20,9 +21,9 @@ const interestingSubjects = async (
     WHERE {
       GRAPH ?g {
         ?s a ?type .
-        VALUES ?type { ${types.map((type) => `<${type}>`).join(" ")} }
+        VALUES ?type { ${types.map((type) => sparqlEscapeUri(type)).join(" ")} }
         VALUES ?s { ${[...subjects]
-          .map((subject) => `<${subject}>`)
+          .map((subject) => sparqlEscapeUri(subject))
           .join(" ")} }
 
         ?s ?predicate ?mandataris.

--- a/config/ldes-delta-pusher/handle-mandataris-type.ts
+++ b/config/ldes-delta-pusher/handle-mandataris-type.ts
@@ -1,5 +1,7 @@
 import { querySudo } from "@lblod/mu-auth-sudo";
+import { sparqlEscapeUri } from "mu";
 import { Changeset } from "../types";
+
 import { publishInterestingSubjects } from "./handle-types-util";
 import { InterestingSubject } from "./publisher";
 import { MANDATARIS_DRAFT_STATE } from "./utils/well-known-uris";
@@ -15,7 +17,7 @@ export const toMandatarisDraftState = async (subjects: string[]) => {
         GRAPH ?g {
           ?s a mandaat:Mandataris.
           VALUES ?s { ${[...subjects]
-            .map((subject) => `<${subject}>`)
+            .map((subject) => sparqlEscapeUri(subject))
             .join(" ")} }
           OPTIONAL { ?s lmb:hasPublicationStatus ?publicationStatus. }
         }

--- a/config/ldes-delta-pusher/handle-membership-type.ts
+++ b/config/ldes-delta-pusher/handle-membership-type.ts
@@ -1,9 +1,10 @@
 import { Changeset } from "../types";
 import { querySudo } from "@lblod/mu-auth-sudo";
+import { v4 as uuidv4 } from "uuid";
 import { sparqlEscapeUri, sparqlEscapeString } from "mu";
+
 import { publishInterestingSubjects } from "./handle-types-util";
 import { InterestingSubject, bindingToTriple } from "./publisher";
-import { v4 as uuidv4 } from "uuid";
 
 const addTimeInterval = async (
   subject: InterestingSubject
@@ -26,14 +27,14 @@ const addTimeInterval = async (
         generiekS:begin ?start ;
         generiekS:einde ?einde ;
         ext:relatedTo ?bestuurseenheid .
-      <${subject.uri}> org:memberDuring ${sparqlEscapeUri(tijdsintervalUri)} .
+      ${sparqlEscapeUri(subject.uri)} org:memberDuring ${sparqlEscapeUri(tijdsintervalUri)} .
     } WHERE {
       GRAPH ?g {
         ?mandataris a mandaat:Mandataris ;
-          org:hasMembership <${subject.uri}> ;
+          org:hasMembership ${sparqlEscapeUri(subject.uri)} ;
           mandaat:start ?start .
         OPTIONAL {
-          <${subject.uri}> mandaat:einde ?einde .
+          ${sparqlEscapeUri(subject.uri)} mandaat:einde ?einde .
         }
       }
       ?g ext:ownedBy ?bestuurseenheid .
@@ -53,7 +54,7 @@ const keepMembershipTypesQuery = async (
         ?g <http://mu.semte.ch/vocabularies/ext/ownedBy> ?bestuurseenheid.
 
         VALUES ?s { ${[...subjects]
-          .map((subject) => `<${subject}>`)
+          .map((subject) => sparqlEscapeUri(subject))
           .join(" ")} }
       }
     `);

--- a/config/ldes-delta-pusher/handle-regular-types.ts
+++ b/config/ldes-delta-pusher/handle-regular-types.ts
@@ -1,5 +1,7 @@
-import { Changeset } from "../types";
 import { querySudo } from "@lblod/mu-auth-sudo";
+import { sparqlEscapeUri } from "mu";
+import { Changeset } from "../types";
+
 import { publishInterestingSubjects } from "./handle-types-util";
 import { InterestingSubject, LDES_TYPE, TypesWithFilter } from "./publisher";
 import { ldesInstances } from "./ldes-instances";
@@ -42,9 +44,9 @@ const keepRegularTypesQuery = async (
         }
         ?g <http://mu.semte.ch/vocabularies/ext/ownedBy> ?bestuurseenheid.
 
-        VALUES ?type { ${types.map((type) => `<${type}>`).join(" ")} }
+        VALUES ?type { ${types.map((type) => sparqlEscapeUri(type)).join(" ")} }
         VALUES ?s { ${[...subjects]
-          .map((subject) => `<${subject}>`)
+          .map((subject) => sparqlEscapeUri(subject))
           .join(" ")} }
       }
     `);

--- a/config/ldes-delta-pusher/handle-types-util.ts
+++ b/config/ldes-delta-pusher/handle-types-util.ts
@@ -1,4 +1,5 @@
 import { Changeset } from "../types";
+
 import { log } from "./logger";
 import { InterestingSubject, publish } from "./publisher";
 


### PR DESCRIPTION
## Description

To prevent sparql injection we need to escape all user input value with the mu package sparqlEscape methods

## How to test

You can write the initial ldes-stream and see if all get parsed correctly in the output files 

## Links to other PR's

- https://github.com/lblod/mandataris-service/pull/86
- https://github.com/lblod/form-content-service/pull/70
