### PR TITLE
lmb-1168 | add query that adds  the hide triple to the bestuurseenheid

### DIFF
--- a/config/migrations/2025/20251102164000-add-hide-iv-triple-to-eenheden.sparql
+++ b/config/migrations/2025/20251102164000-add-hide-iv-triple-to-eenheden.sparql
@@ -1,0 +1,15 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+INSERT {
+  GRAPH ?g {
+    ?bestuurseenheid ext:voorbereidingVerborgen true .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?bestuurseenheid a besluit:Bestuurseenheid .
+  }
+  ?g ext:ownedBy ?someone .
+  BIND(?someone as ?bestuurseenheid)
+}

--- a/config/migrations/2025/20251102164000-add-hide-iv-triple-to-eenheden.sparql
+++ b/config/migrations/2025/20251102164000-add-hide-iv-triple-to-eenheden.sparql
@@ -1,15 +1,16 @@
-PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
 PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 INSERT {
   GRAPH ?g {
-    ?bestuurseenheid ext:voorbereidingVerborgen true .
+    ?bestuurseenheid ext:voorbereidingVerborgen "true"^^xsd:boolean .
   }
 }
 WHERE {
   GRAPH ?g {
-    ?bestuurseenheid a besluit:Bestuurseenheid .
+    ?iv lmb:hasStatus <http://data.lblod.info/id/concept/InstallatievergaderingStatus/c9fc3292-1576-4a82-8dcd-60795e22131f> . # Behandeld
   }
   ?g ext:ownedBy ?someone .
-  BIND(?someone as ?bestuurseenheid)
+  BIND(?someone AS ?bestuurseenheid)
 }

--- a/config/resources/external-besluit.lisp
+++ b/config/resources/external-besluit.lisp
@@ -43,6 +43,7 @@
                 (:wil-mail-ontvangen :boolean ,(s-prefix "ext:wilMailOntvangen")) ;;Voorkeur in berichtencentrum
                 (:mail-adres :string ,(s-prefix "ext:mailAdresVoorNotificaties"))
                 (:is-trial-user :boolean ,(s-prefix "ext:isTrailUser"))
+                (:hide-legislatuur :boolean ,(s-prefix "ext:voorbereidingVerborgen"))
                 (:view-only-modules :string-set ,(s-prefix "ext:viewOnlyModules")))
   :has-one `((werkingsgebied :via ,(s-prefix "besluit:werkingsgebied")
                              :as "werkingsgebied")

--- a/config/resources/verkiezingen.lisp
+++ b/config/resources/verkiezingen.lisp
@@ -1,7 +1,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Installatievergaderingen ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (define-resource installatievergadering ()
   :class (s-prefix "lmb:Installatievergadering")
-  :properties `((:is-hidden :boolean ,(s-prefix "ext:voorbereidingVerborgen")))
   :has-one `((installatievergadering-status :via ,(s-prefix "lmb:hasStatus")
                                             :as "status")
              (bestuurseenheid :via ,(s-prefix "lmb:heeftBestuurseenheid")

--- a/config/resources/verkiezingen.lisp
+++ b/config/resources/verkiezingen.lisp
@@ -1,6 +1,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Installatievergaderingen ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (define-resource installatievergadering ()
   :class (s-prefix "lmb:Installatievergadering")
+  :properties `((:is-hidden :boolean ,(s-prefix "ext:voorbereidingVerborgen")))
   :has-one `((installatievergadering-status :via ,(s-prefix "lmb:hasStatus")
                                             :as "status")
              (bestuurseenheid :via ,(s-prefix "lmb:heeftBestuurseenheid")


### PR DESCRIPTION
## Description

We want to add a temporary triple to the bestuurseenheden to hide the legislatuur module `ext:voorbereidingVerborgen`

## How to test

- There should be **551** bestuurseenheden with this triple
```sparql
  PREFIX org: <http://www.w3.org/ns/org#>
  PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
  PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
  
  SELECT COUNT(DISTINCT ?iv) AS ?count
      WHERE {
        GRAPH ?g {
          ?iv lmb:hasStatus <http://data.lblod.info/id/concept/InstallatievergaderingStatus/c9fc3292-1576-4a82-8dcd-60795e22131f> . # Behandeld
        }
        ?g ext:ownedBy ?someone .
      }

```
- There should still remain **53** bestuurseenheden without this triple
```sparql
  PREFIX org: <http://www.w3.org/ns/org#>
  PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
  PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>

  SELECT COUNT(DISTINCT ?iv) AS ?count 
      WHERE {
        GRAPH ?g {
          VALUES ?status {
                  <http://data.lblod.info/id/concept/InstallatievergaderingStatus/a40b8f8a-8de2-4710-8d9b-3fc43a4b740e>  # Klaar voor vergadering
                  <http://data.lblod.info/id/concept/InstallatievergaderingStatus/b54dbe98-d618-4af7-9f01-791aa90774e4>  # Te behandelen
          }
          ?iv lmb:hasStatus ?status .
        }
        ?g ext:ownedBy ?someone .
      }

```

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/489
