### PR TITLE
Ben/lmb 1412 multiple startdates

### DIFF
--- a/config/migrations/2025/20250224071303-remove-duplicate-startdates.sparql
+++ b/config/migrations/2025/20250224071303-remove-duplicate-startdates.sparql
@@ -20,11 +20,11 @@ WHERE {
   }
   BIND(NOW() AS ?now)
   VALUES (?mandataris ?start) {
-    (<http://data.lblod.info/id/mandatarissen/a42a5194-1059-4d36-b69d-0216d076d0b7> "2024-12-05T00:00:00"^^xsd:dateTime)
-    (<http://data.lblod.info/id/mandatarissen/5dfb3796-c5d1-4c5a-a398-ce31eba16999> "2024-12-05T00:00:00"^^xsd:dateTime)
-    (<http://data.lblod.info/id/mandatarissen/dd8e9e6f-e843-4418-a963-8e4f75019df0> "2024-12-05T00:00:00"^^xsd:dateTime)
-    (<http://data.lblod.info/id/mandatarissen/3404e976-8aaa-4154-be80-b0200e8805ff> "2024-12-05T00:00:00"^^xsd:dateTime)
-    (<http://data.lblod.info/id/mandatarissen/13b613b5-664b-4b7b-88cc-0518d9c62973> "2024-12-05T00:00:00"^^xsd:dateTime)
-    (<http://data.lblod.info/id/mandatarissen/fac56a27-0a0a-429c-9649-22c1696114cd> "2024-12-05T00:00:00"^^xsd:dateTime)
+    (<http://data.lblod.info/id/mandatarissen/a42a5194-1059-4d36-b69d-0216d076d0b7> "2024-12-05T23:00:00Z"^^xsd:dateTime)
+    (<http://data.lblod.info/id/mandatarissen/5dfb3796-c5d1-4c5a-a398-ce31eba16999> "2024-12-05T23:00:00Z"^^xsd:dateTime)
+    (<http://data.lblod.info/id/mandatarissen/dd8e9e6f-e843-4418-a963-8e4f75019df0> "2024-12-05T23:00:00Z"^^xsd:dateTime)
+    (<http://data.lblod.info/id/mandatarissen/3404e976-8aaa-4154-be80-b0200e8805ff> "2024-12-05T23:00:00Z"^^xsd:dateTime)
+    (<http://data.lblod.info/id/mandatarissen/13b613b5-664b-4b7b-88cc-0518d9c62973> "2024-12-05T23:00:00Z"^^xsd:dateTime)
+    (<http://data.lblod.info/id/mandatarissen/fac56a27-0a0a-429c-9649-22c1696114cd> "2024-12-05T23:00:00Z"^^xsd:dateTime)
   }
 }

--- a/config/migrations/2025/20250224071303-remove-duplicate-startdates.sparql
+++ b/config/migrations/2025/20250224071303-remove-duplicate-startdates.sparql
@@ -1,0 +1,30 @@
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX dct: <http://purl.org/dc/terms/>
+DELETE {
+  GRAPH ?g {
+    ?mandataris mandaat:start ?start .
+    ?mandataris dct:modified ?oldModified .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?mandataris dct:modified ?now .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?mandataris a mandaat:Mandataris ;
+      mandaat:start ?start ;
+      dct:modified ?oldModified .
+  }
+  BIND(NOW() AS ?now)
+  VALUES (?mandataris ?start) {
+    (<http://data.lblod.info/id/mandatarissen/a42a5194-1059-4d36-b69d-0216d076d0b7> "2024-12-05T00:00:00"^^xsd:dateTime)
+    (<http://data.lblod.info/id/mandatarissen/5dfb3796-c5d1-4c5a-a398-ce31eba16999> "2024-12-05T00:00:00"^^xsd:dateTime)
+    (<http://data.lblod.info/id/mandatarissen/dd8e9e6f-e843-4418-a963-8e4f75019df0> "2024-12-05T00:00:00"^^xsd:dateTime)
+    (<http://data.lblod.info/id/mandatarissen/3404e976-8aaa-4154-be80-b0200e8805ff> "2024-12-05T00:00:00"^^xsd:dateTime)
+    (<http://data.lblod.info/id/mandatarissen/13b613b5-664b-4b7b-88cc-0518d9c62973> "2024-12-05T00:00:00"^^xsd:dateTime)
+    (<http://data.lblod.info/id/mandatarissen/fac56a27-0a0a-429c-9649-22c1696114cd> "2024-12-05T00:00:00"^^xsd:dateTime)
+  }
+}


### PR DESCRIPTION
## Description

Remove one of multiple startdates of mandatarissen with two startdates.
Selected the one that was the most common in the bestuursorgaan.

## How to test

Run the migration and you can run the following query to check there are no more mandatarissen with duplicate startdates. You can also go check in the OCMW Wellen if the start dates of the mandatarissen make sense there.
```
PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
PREFIX org: <http://www.w3.org/ns/org#>
PREFIX bestuursperiode: <http://data.lblod.info/id/concept/Bestuursperiode/>
  SELECT DISTINCT ?mandataris WHERE {
    GRAPH ?g {
      ?mandataris a mandaat:Mandataris ;
        org:holds / ^ org:hasPost / lmb:heeftBestuursperiode bestuursperiode:96efb929-5d83-48fa-bfbb-b98dfb1180c7 ; # 2025 - heden
        mandaat:start ?start1 ;
        mandaat:start ?start2 .
      FILTER (?start1 != ?start2)
    }
    ?g ext:ownedBy ?bestuurseenheid .
  }

```
