### PR TITLE
Lmb 1407 | Soft removal draft publication status

### DIFF
--- a/config/migrations/2025/20250224091000-publication-status-niet-bekrachtigd.sparql
+++ b/config/migrations/2025/20250224091000-publication-status-niet-bekrachtigd.sparql
@@ -1,0 +1,20 @@
+PREFIX mps: <http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#> 
+PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    mps:d3b12468-3720-4cb0-95b4-6aa2996ab188 skos:prefLabel ?label .
+  }
+}
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    mps:d3b12468-3720-4cb0-95b4-6aa2996ab188 skos:prefLabel "Niet bekrachtigd" .
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    mps:d3b12468-3720-4cb0-95b4-6aa2996ab188 a lmb:MandatarisPublicationStatusCode  . # Effectief status
+    mps:d3b12468-3720-4cb0-95b4-6aa2996ab188 skos:prefLabel ?label .
+  }
+}

--- a/config/migrations/2025/20250224124500-draft-to-niet-bekrachtigd-for-non-iv-mandatarissen.sparql
+++ b/config/migrations/2025/20250224124500-draft-to-niet-bekrachtigd-for-non-iv-mandatarissen.sparql
@@ -1,0 +1,40 @@
+prefix org: <http://www.w3.org/ns/org#>
+prefix lmb: <http://lblod.data.gift/vocabularies/lmb/>
+prefix ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX dct: <http://purl.org/dc/terms/>
+
+DELETE {
+  GRAPH ?g {
+    ?mandataris lmb:hasPublicationStatus ?draftStatus .
+    ?mandataris dct:modified ?modified .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?mandataris lmb:hasPublicationStatus <http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/d3b12468-3720-4cb0-95b4-6aa2996ab188> . # Niet bekrachtigd formal effectief status
+    ?mandataris dct:modified ?now .
+  }
+}
+WHERE {
+  {
+    GRAPH ?g {
+      ?mandataris lmb:hasPublicationStatus <http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/588ce330-4abb-4448-9776-a17d9305df07> . # Draft publication status
+      ?mandataris org:holds / ^org:hasPost ?boi .
+      ?boi lmb:heeftBestuursperiode ?bestuursperiode .
+      FILTER(?bestuursperiode != <http://data.lblod.info/id/concept/Bestuursperiode/96efb929-5d83-48fa-bfbb-b98dfb1180c7>) # All other periods than 2024 - heden
+    }
+    ?g ext:ownedBy ?eenheid .
+  } UNION {
+    SELECT DISTINCT ?mandataris
+    WHERE {
+      GRAPH ?g {
+        ?mandataris lmb:hasPublicationStatus <http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/588ce330-4abb-4448-9776-a17d9305df07> . # Draft publication status
+        ?mandataris org:holds / ^org:hasPost ?boi .
+        ?boi lmb:heeftBestuursperiode <http://data.lblod.info/id/concept/Bestuursperiode/96efb929-5d83-48fa-bfbb-b98dfb1180c7> . #2024 - heden
+
+        ?eenheid ext:voorbereidingVerborgen ?isIvFinished . # IV must be finished
+      }
+      ?g ext:ownedBy ?eenheid .
+    }
+  }
+}


### PR DESCRIPTION
## Description

- Change the label of mandataris publicatie status to "Niet bekrachtigd"
- Change the status from `Draft` to `Niet bekrachtigd` for all madatarissen except for the onces still in an active IV

## How to test

- The database should not contain any mandataris with publication status Draft
- Label show in frontend should be `Niet bekrachtigd`

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/500
