### PR TITLE
add ldes-client tracking op

### DIFF
--- a/config/op-ldes-client/handleStreamEnd.ts
+++ b/config/op-ldes-client/handleStreamEnd.ts
@@ -1,0 +1,4 @@
+export async function handleStreamEnd() {
+  // nothing special
+  console.log("stream has ended");
+}

--- a/config/op-ldes-client/processPage.ts
+++ b/config/op-ldes-client/processPage.ts
@@ -1,0 +1,121 @@
+// this is a winston logger
+import { logger } from "../logger";
+import { updateSudo } from "@lblod/mu-auth-sudo";
+import { sparqlEscapeUri } from "mu";
+import {
+  BATCH_GRAPH,
+  BYPASS_MU_AUTH,
+  DIRECT_DATABASE_CONNECTION,
+  TIME_PREDICATE,
+  VERSION_PREDICATE,
+} from "../environment";
+
+async function replaceExistingData() {
+  let options = {};
+  if (BYPASS_MU_AUTH) {
+    console.log(">>>>> bypassing mu-auth");
+    options = {
+      sparqlEndpoint: DIRECT_DATABASE_CONNECTION,
+    };
+  }
+  await replaceBestuurseenheden(options);
+  await moveBestuursorgaanAndMandate(options);
+}
+
+async function replaceBestuurseenheden(connectionOptions) {
+  await updateSudo(
+    `
+    PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+    PREFIX org: <http://www.w3.org/ns/org#>
+
+    DELETE {
+      GRAPH <http://mu.semte.ch/graphs/public> {
+        ?s ?pOld ?oOld.
+      }
+    }
+    INSERT {
+      GRAPH <http://mu.semte.ch/graphs/public> {
+        ?s ?pNew ?oNew.
+        ?s besluit:classificatie ?bestuurseenheidClassification.
+      }
+    } WHERE {
+      VALUES ?bestuurseenheidClassifications {
+        <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000> # Provincie
+        <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001> # Gemeente
+        <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002> # OCMW
+        <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000003> # District
+        <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> # Politiezone
+      }
+      GRAPH ${sparqlEscapeUri(BATCH_GRAPH)} {
+        ?stream <https://w3id.org/tree#member> ?versionedMember .
+        ?versionedMember ${sparqlEscapeUri(VERSION_PREDICATE)} ?s .
+        ?versionedMember ?pNew ?oNew.
+        ?versionedMember org:classification ?bestuurseenheidClassification.
+        FILTER (?pNew NOT IN ( ${sparqlEscapeUri(
+          VERSION_PREDICATE
+        )}, ${sparqlEscapeUri(TIME_PREDICATE)} ))
+      }
+      OPTIONAL {
+        GRAPH <http://mu.semte.ch/graphs/public> {
+          ?s ?pOld ?oOld.
+        }
+      }
+    }`,
+    {},
+    connectionOptions
+  );
+}
+
+// we are counting on the ldes providing a direct link to the eenheid that owns the concept so we can put it
+// in the right graph. This also means that the bestuurseenheid always needs to have been published before the concept itself
+async function moveBestuursorgaanAndMandate(connectionOptions) {
+  await updateSudo(
+    `
+    PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+    PREFIX org: <http://www.w3.org/ns/org#>
+    PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+    DELETE {
+      GRAPH ?targetGraph {
+        ?s ?pOld ?oOld.
+      }
+    }
+    INSERT {
+      GRAPH ?targetGraph {
+        ?s ?pNew ?oNew.
+      }
+    } WHERE {
+      GRAPH ${sparqlEscapeUri(BATCH_GRAPH)} {
+        ?stream <https://w3id.org/tree#member> ?versionedMember .
+        ?versionedMember ${sparqlEscapeUri(VERSION_PREDICATE)} ?s .
+        VALUES ?type {
+          besluit:Bestuursorgaan
+          mandaat:Mandaat
+        }
+        ?versionedMember a ?type.
+        ?versionedMember ?pNew ?oNew.
+        ?versionedMember ext:owningBestuurseenheid ?eenheid.
+        FILTER (?pNew NOT IN ( ${sparqlEscapeUri(
+          VERSION_PREDICATE
+        )}, ${sparqlEscapeUri(TIME_PREDICATE)} ))
+      }
+      ?eenheid mu:uuid ?id.
+      BIND(IRI(CONCAT("http://mu.semte.ch/graphs/organizations/", ?id, "/LoketLB-mandaatGebruiker")) AS ?targetGraph)
+      OPTIONAL {
+        GRAPH ?targetGraph {
+          ?s ?pOld ?oOld.
+        }
+      }
+    }`,
+    {},
+    connectionOptions
+  );
+}
+
+export async function processPage() {
+  logger.debug("Running custom logic to process the current page");
+  await replaceExistingData();
+  return;
+}

--- a/config/op-ldes-client/processPage.ts
+++ b/config/op-ldes-client/processPage.ts
@@ -36,7 +36,7 @@ async function replaceBestuurseenheden(connectionOptions) {
     }
     INSERT {
       GRAPH <http://mu.semte.ch/graphs/public> {
-        ?s ?pNew ?oNew.
+        ?s ?pNewReal ?oNew.
         ?s besluit:classificatie ?bestuurseenheidClassification.
       }
     } WHERE {
@@ -56,6 +56,10 @@ async function replaceBestuurseenheden(connectionOptions) {
           VERSION_PREDICATE
         )}, ${sparqlEscapeUri(TIME_PREDICATE)} ))
       }
+      VALUES ( ?pNewReplace ?pNewReplaced ) {
+        ( org:classification besluit:classificatie )
+      }
+      BIND(IF(?pNew = ?pNewReplace, ?pNewReplaced, ?pNew) AS ?pNewReal)
       OPTIONAL {
         GRAPH <http://mu.semte.ch/graphs/public> {
           ?s ?pOld ?oOld.
@@ -78,6 +82,7 @@ async function moveBestuursorgaanAndMandate(connectionOptions) {
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
+    PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
 
     DELETE {
       GRAPH ?targetGraph {
@@ -86,7 +91,7 @@ async function moveBestuursorgaanAndMandate(connectionOptions) {
     }
     INSERT {
       GRAPH ?targetGraph {
-        ?s ?pNew ?oNew.
+        ?s ?pNewReal ?oNew.
       }
     } WHERE {
       GRAPH ${sparqlEscapeUri(BATCH_GRAPH)} {
@@ -108,9 +113,14 @@ async function moveBestuursorgaanAndMandate(connectionOptions) {
       OPTIONAL {
         GRAPH ?targetGraph {
           ?s ?pOld ?oOld.
-          FILTER(?pOld NOT IN (ext:isTijdelijkOrgaanIn, ext:origineleBestuurseenheid, lmb:heeftBestuursperiode, lmb:deactivatedAt ))
+          FILTER(?pOld NOT IN (ext:isTijdelijkOrgaanIn, ext:origineleBestuurseenheid, lmb:heeftBestuursperiode, lmb:deactivatedAt, ext:origineleBestuursorgaan ))
         }
       }
+      VALUES ( ?pNewReplace ?pNewReplaced ) {
+        ( generiek:isTijdspecialisatieVan mandaat:isTijdspecialisatieVan )
+        ( org:classification besluit:classificatie )
+      }
+      BIND(IF(?pNew = ?pNewReplace, ?pNewReplaced, ?pNew) AS ?pNewReal)
     }`,
     {},
     connectionOptions

--- a/config/op-ldes-client/processPage.ts
+++ b/config/op-ldes-client/processPage.ts
@@ -76,6 +76,7 @@ async function moveBestuursorgaanAndMandate(connectionOptions) {
     PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
 
     DELETE {
       GRAPH ?targetGraph {
@@ -106,6 +107,7 @@ async function moveBestuursorgaanAndMandate(connectionOptions) {
       OPTIONAL {
         GRAPH ?targetGraph {
           ?s ?pOld ?oOld.
+          FILTER(?pOld NOT IN (ext:isTijdelijkOrgaanIn, ext:origineleBestuurseenheid, lmb:heeftBestuursperiode, lmb:deactivatedAt ))
         }
       }
     }`,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -256,9 +256,6 @@ services:
       - "./data/ldes-feed/:/data/"
   decision-ldes-client:
     image: lblod/ldes-client:0.0.3
-    links:
-      - database:database
-      - virtuoso:virtuoso
     restart: always
     environment:
       LDES_BASE: https://mandaten-besluiten.lblod.info/streams/ldes/public/
@@ -272,6 +269,26 @@ services:
     labels:
       - "logging=true"
     logging: *default-logging
+  op-ldes-client:
+    image: lblod/ldes-client:0.0.3
+    restart: always
+    environment:
+      LDES_BASE: https://data.lblod.info/op/ldes/
+      FIRST_PAGE: https://data.lblod.info/op/ldes/1
+      # this is a default, most concepts will be assigned to their graph based on corresponding bestuurseenheid
+      TARGET_GRAPH: http://mu.semte.ch/graphs/public
+      WORKING_GRAPH: http://mu.semte.ch/graphs/op-consumed-tmp
+      DIRECT_DATABASE_CONNECTION: "http://virtuoso:8890/sparql"
+      CRON_PATTERN: "30 * * * *"
+      RANDOMIZE_GRAPHS: true
+      BATCH_SIZE: 100
+      BYPASS_MU_AUTH: false
+    volumes:
+      - ./config/op-ldes-client:/config
+    labels:
+      - "logging=true"
+    logging: *default-logging
+
   ##############################################################################
   # VENDOR ENDPOINTS
   ##############################################################################

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -255,7 +255,7 @@ services:
     volumes:
       - "./data/ldes-feed/:/data/"
   decision-ldes-client:
-    image: lblod/ldes-client:0.0.3
+    image: lblod/ldes-client:0.0.4
     restart: always
     environment:
       LDES_BASE: https://mandaten-besluiten.lblod.info/streams/ldes/public/
@@ -270,7 +270,7 @@ services:
       - "logging=true"
     logging: *default-logging
   op-ldes-client:
-    image: lblod/ldes-client:0.0.3
+    image: lblod/ldes-client:0.0.4
     restart: always
     environment:
       LDES_BASE: https://data.lblod.info/op/ldes/


### PR DESCRIPTION
## Description

This adds an ldes client that tracks the new OP ldes stream
## How to test

- clone the OP application with the changes that publish the new stream, see linked PR
- download the dev db contents and add it locally, don't bother with the mu-search indexes
- you can disable most of the app, you just need the triplestore, db, and ldes-delta-pusher services
- enable write-initial-state on the ldes-delta-pusher service and generate the stream
- you should now have a stream of about 11pages
- rename ldes-backend to ldes-backend-op and add it to the debug network of our app, you can kill all other op services
- now enable initial load on the lmb op ldes client and run it
- notice that the stream is being loaded, should not take more than 5 minutes
- after that, kill and restart resource and cache
- see that all bestuurseenheden, organen and mandaten are still there in our app but are now updated. Check gemeente, ocmw, district, province
- you can check live updates by either modifying the op stream files yourself OR by modifying the op concepts through their frontend but this requires some fiddling (run both stacks at once, manually go to an op bestuursorgaan in tijd url as you don't have search, update it, see the change coming in. In theory you can also do this while the lmb stack is down if your machine can't handle it as the changes are async by nature.

## Related PRs
- https://github.com/lblod/app-organization-portal/pull/520

