### PR TITLE
better report generation

### DIFF
--- a/config/reports/helpers.js
+++ b/config/reports/helpers.js
@@ -67,7 +67,7 @@ export async function getBestuurseenhedenUriAndUuidsToProcess(
                             besluit:classificatie ?bestuurseenheidClassificatie .
 
             {
-              SELECT ?bestuurseenheid MAX(?created) as ?latestCreated WHERE {
+              SELECT ?bestuurseenheid (MAX(?safeCreated) AS ?latestCreated) WHERE {
                 GRAPH ?g {
                   ?org besluit:bestuurt ?bestuurseenheid .
                   OPTIONAL {
@@ -82,9 +82,9 @@ export async function getBestuurseenhedenUriAndUuidsToProcess(
             }
 
             ${sparqlValuesBestuurseenheidClassificaties}
-        } ORDER BY ASC(?safeCreated) LIMIT ${BATCH_SIZE}
+        } ORDER BY ASC(?latestCreated) LIMIT ${BATCH_SIZE}
     `;
-  const queryResponse = await sudoQuery(queryStringBestuurseenheden);
+  const queryResponse = await querySudo(queryStringBestuurseenheden);
   const uriAndUuids = queryResponse.results.bindings.map((res) => {
     return { uri: res.uri.value, uuid: res.uuid.value };
   });

--- a/config/reports/helpers.js
+++ b/config/reports/helpers.js
@@ -623,7 +623,7 @@ export async function deletePreviousReports(namedGraphs) {
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX sh: <http://www.w3.org/ns/shacl#>
 
-    SELECT ?reportUri
+    SELECT DISTINCT ?reportUri
     WHERE {
         VALUES ?g {
           ${namedGraphs.map((g) => sparqlEscapeUri(g)).join("\n")}

--- a/config/reports/shacl-report.js
+++ b/config/reports/shacl-report.js
@@ -50,6 +50,13 @@ export default {
     // Validate for each bestuurseenheid
     for (const uriAndUuid of uriAndUuids) {
       try {
+        const namedGraphs = await getNamedGraphsForBestuurseenheidId(
+          uriAndUuid.uuid
+        );
+
+        if (ONLY_KEEP_LATEST_REPORT) {
+          await deletePreviousReports(namedGraphs);
+        }
         // Retrieve all triples within the bestuurseenheid graph limited to the bestuursperiode
         const dataDataset = await executeConstructQueriesOnNamedGraph(
           uriAndUuid,
@@ -69,10 +76,6 @@ export default {
           report.dataset,
           shapesDataset,
           dataDataset
-        );
-
-        const namedGraphs = await getNamedGraphsForBestuurseenheidId(
-          uriAndUuid.uuid
         );
 
         saveDatasetToNamedGraphs(enrichedValidationReportDataset, namedGraphs);

--- a/config/reports/shacl-report.js
+++ b/config/reports/shacl-report.js
@@ -44,6 +44,10 @@ const cronFunction = async () => {
   const shape = await mergeFilesContent("./config/shacl");
   const shapesDataset = await parseTurtleString(shape);
 
+  console.log(
+    `Will process ${uriAndUuids.length} bestuurseenheden during this run`
+  );
+
   // Validate for each bestuurseenheid
   for (const uriAndUuid of uriAndUuids) {
     try {
@@ -77,7 +81,7 @@ const cronFunction = async () => {
         dataDataset
       );
 
-      saveDatasetToNamedGraphs(enrichedValidationReportDataset, namedGraphs);
+      await saveDatasetToNamedGraphs(enrichedValidationReportDataset, namedGraphs);
       console.log(`SHACL validation report saved in triple store.`);
 
       if (ONLY_KEEP_LATEST_REPORT) {
@@ -86,7 +90,11 @@ const cronFunction = async () => {
     } catch (error) {
       console.error("Error:", error);
     }
+    console.log(
+      `SHACL validation for bestuurseenheid ${uriAndUuid.uuid} done.`
+    );
   }
+  console.log(`Done processing ${uriAndUuids.length} bestuurseenheden.`);
 };
 
 export default {

--- a/config/reports/shacl-report.js
+++ b/config/reports/shacl-report.js
@@ -18,75 +18,84 @@ const ONLY_KEEP_LATEST_REPORT =
 
 const reportName = "ShaclReport";
 
+const cronFunction = async () => {
+  console.log("report starts");
+  const reportInfo = {
+    title: reportName,
+    description: "SHACL validatie per bestuur (gemeente en OCMW)",
+    filePrefix: "report-shacl",
+  };
+
+  // Configure here the bestuurseenheidclassificaties (gemeente, OCMW) to validate
+  const interestedBestuurseenheidClassificaties = [
+    "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001",
+    // since we also include the ocmw data when validating the gemeente, we don't need to validate ocmw separately
+    // "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002",
+  ];
+  // Configure the bestuursperiode to validate
+  const bestuursperiodeLabel = "2024 - heden";
+
+  // Retrieve URI and UUID of bestuurseenheden
+  const uriAndUuids = await getBestuurseenhedenUriAndUuidsToProcess(
+    interestedBestuurseenheidClassificaties
+  );
+
+  // Read all SHACL files in the shacl folder
+  const shape = await mergeFilesContent("./config/shacl");
+  const shapesDataset = await parseTurtleString(shape);
+
+  // Validate for each bestuurseenheid
+  for (const uriAndUuid of uriAndUuids) {
+    try {
+      const namedGraphs = await getNamedGraphsForBestuurseenheidId(
+        uriAndUuid.uuid
+      );
+
+      if (ONLY_KEEP_LATEST_REPORT) {
+        await deletePreviousReports(namedGraphs);
+      }
+      // Retrieve all triples within the bestuurseenheid graph limited to the bestuursperiode
+      const dataDataset = await executeConstructQueriesOnNamedGraph(
+        uriAndUuid,
+        bestuursperiodeLabel
+      );
+
+      console.log(
+        `Running SHACL validation for bestuurseenheid ${uriAndUuid.uuid} on store of size ${dataDataset.size}...`
+      );
+      const startTime = Date.now();
+      const report = await validateDataset(dataDataset, shapesDataset);
+      const endTime = Date.now();
+      console.log(
+        `SHACL validation took ${(endTime - startTime) / 1000} seconds.`
+      );
+
+      // Enrich validation report by removing blank nodes, adding timestamp etc.
+      const enrichedValidationReportDataset = enrichValidationReport(
+        report.dataset,
+        shapesDataset,
+        dataDataset
+      );
+
+      saveDatasetToNamedGraphs(enrichedValidationReportDataset, namedGraphs);
+      console.log(`SHACL validation report saved in triple store.`);
+
+      if (ONLY_KEEP_LATEST_REPORT) {
+        await deletePreviousReports(namedGraphs);
+      }
+    } catch (error) {
+      console.error("Error:", error);
+    }
+  }
+};
+
 export default {
   cronPattern: "0 3 * * *",
   name: reportName,
-  execute: async () => {
-    console.log("report starts");
-    const reportInfo = {
-      title: reportName,
-      description: "SHACL validatie per bestuur (gemeente en OCMW)",
-      filePrefix: "report-shacl",
-    };
-
-    // Configure here the bestuurseenheidclassificaties (gemeente, OCMW) to validate
-    const interestedBestuurseenheidClassificaties = [
-      "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001",
-      // since we also include the ocmw data when validating the gemeente, we don't need to validate ocmw separately
-      // "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002",
-    ];
-    // Configure the bestuursperiode to validate
-    const bestuursperiodeLabel = "2024 - heden";
-
-    // Retrieve URI and UUID of bestuurseenheden
-    const uriAndUuids = await getBestuurseenhedenUriAndUuidsToProcess(
-      interestedBestuurseenheidClassificaties
-    );
-
-    // Read all SHACL files in the shacl folder
-    const shape = await mergeFilesContent("./config/shacl");
-    const shapesDataset = await parseTurtleString(shape);
-
-    // Validate for each bestuurseenheid
-    for (const uriAndUuid of uriAndUuids) {
-      try {
-        const namedGraphs = await getNamedGraphsForBestuurseenheidId(
-          uriAndUuid.uuid
-        );
-
-        if (ONLY_KEEP_LATEST_REPORT) {
-          await deletePreviousReports(namedGraphs);
-        }
-        // Retrieve all triples within the bestuurseenheid graph limited to the bestuursperiode
-        const dataDataset = await executeConstructQueriesOnNamedGraph(
-          uriAndUuid,
-          bestuursperiodeLabel
-        );
-
-        console.log("Running SHACL validation...");
-        const startTime = Date.now();
-        const report = await validateDataset(dataDataset, shapesDataset);
-        const endTime = Date.now();
-        console.log(
-          `SHACL validation took ${(endTime - startTime) / 1000} seconds.`
-        );
-
-        // Enrich validation report by removing blank nodes, adding timestamp etc.
-        const enrichedValidationReportDataset = enrichValidationReport(
-          report.dataset,
-          shapesDataset,
-          dataDataset
-        );
-
-        saveDatasetToNamedGraphs(enrichedValidationReportDataset, namedGraphs);
-        console.log(`SHACL validation report saved in triple store.`);
-
-        if (ONLY_KEEP_LATEST_REPORT) {
-          await deletePreviousReports(namedGraphs);
-        }
-      } catch (error) {
-        console.error("Error:", error);
-      }
-    }
-  },
+  execute: cronFunction,
 };
+
+if (process.env.RUN_REPORT_NOW) {
+  console.log("Running report in 10 seconds");
+  setTimeout(() => cronFunction(), 10000);
+}

--- a/config/reports/shacl-report.js
+++ b/config/reports/shacl-report.js
@@ -1,6 +1,6 @@
 import {
   mergeFilesContent,
-  getBestuurseenhedenUriAndUuid,
+  getBestuurseenhedenUriAndUuidsToProcess,
   executeConstructQueriesOnNamedGraph,
   parseTurtleString,
   validateDataset,
@@ -39,7 +39,7 @@ export default {
     const bestuursperiodeLabel = "2024 - heden";
 
     // Retrieve URI and UUID of bestuurseenheden
-    const uriAndUuids = await getBestuurseenhedenUriAndUuid(
+    const uriAndUuids = await getBestuurseenhedenUriAndUuidsToProcess(
       interestedBestuurseenheidClassificaties
     );
 


### PR DESCRIPTION
## Description

improvements to report generation service:
- allow running reports on start for debugging
- run batches of eenheden at nightly run, based on which has the oldest report (batch size 50 by default)
- fix old report deletion
## How to test

run the reports on start with a batch size of 3, see that three eenheden are processed and the system then stops.
run it again and see 3 new eenheden are processed