### PR TITLE
lmb-1428 | Notification for mandataris that is more than 10 days active

### DIFF
--- a/config/migrations/2025/20250311092100-remove-all-emails-from-outbox.sparql
+++ b/config/migrations/2025/20250311092100-remove-all-emails-from-outbox.sparql
@@ -9,7 +9,7 @@ DELETE {
 WHERE {
   GRAPH ?g {
     ?mail a nmo:Email .
-    ?mail nmo:isPartOf mailFolders:2 .
+    ?mail nmo:isPartOf mailFolders:2 . # Outbox
     ?mail ?p ?o .
   }
 }

--- a/config/migrations/2025/20250311092100-remove-all-emails-from-to-send-folder.sparql
+++ b/config/migrations/2025/20250311092100-remove-all-emails-from-to-send-folder.sparql
@@ -1,0 +1,15 @@
+PREFIX nmo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#>
+PREFIX mailFolders: <http://data.lblod.info/id/mail-folders/>
+
+DELETE {
+  GRAPH ?g {
+    ?mail ?p ?o .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?mail a nmo:Email .
+    ?mail nmo:isPartOf mailFolders:2 .
+    ?mail ?p ?o .
+  }
+}

--- a/config/resources/external-mandaat.lisp
+++ b/config/resources/external-mandaat.lisp
@@ -80,8 +80,7 @@
                 (:generated-from :uri-set ,(s-prefix "ext:generatedFrom")) ;;if it e.g. comes from gelinkt-notuleren
                 (:duplication-reason :string ,(s-prefix "skos:changeNote"))
                 (:link-to-besluit :string ,(s-prefix "lmb:linkToBesluit"))
-                (:modified :datetime ,(s-prefix "dct:modified"))
-                (:effectief-at :datetime ,(s-prefix "lmb:effectiefAt")))
+                (:modified :datetime ,(s-prefix "dct:modified")))
   :has-many `((mandataris :via ,(s-prefix "mandaat:isTijdelijkVervangenDoor")
                           :as "tijdelijke-vervangingen")
               (mandataris :via ,(s-prefix "mandaat:isTijdelijkVervangenDoor")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,8 +163,8 @@ services:
       - ./data/files/burgemeester-benoemingen:/uploads
     environment:
       NOTIFICATION_CRON_PATTERN: 0 8 * * 1-5
-      EMAIL_FROM_MANDATARIS_EFFECTIEF: "lokaalmandatenbeheer@vlaanderen.be" # Must be the same as EMAIL_ADDRESS in deliver-email service
-      SEND_EMAIL_FOR_MANDATARIS_EFFECTIEF: false
+      EMAIL_FROM_MANDATARIS_WITHOUT_DECISION: "lokaalmandatenbeheer@vlaanderen.be" # Must be the same as EMAIL_ADDRESS in deliver-email service
+      SEND_EMAIL_FOR_MANDATARIS_WITHOUT_DECISION: false
       BESLUIT_STAGING_GRAPH: http://mu.semte.ch/graphs/besluiten-consumed # must be the same as decision-ldes-client working graph
   adressenregister:
     image: lblod/adressenregister-fuzzy-search-service:0.8.0


### PR DESCRIPTION
## Description

We want to change the logic for notifications. Before 10 days after effectief (niet-bekrachtigd publication status) a notification was send (this was disabled). We do want these notifications but when a mandataris is active for more than 10 days. (start date + 10 days  > today)

## How to test

- see mandataris service

## Links to other PR's

- [mandataris](https://github.com/lblod/mandataris-service/pull/108)
- [frontend](https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/515)
