### PR TITLE
LMB-1444 add timezone to mandataris service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,7 +154,7 @@ services:
     volumes:
       - ./config/form-content:/config
   mandataris:
-    image: lblod/mandataris-service:0.5.7
+    image: lblod/mandataris-service:0.5.8-tz
     labels:
       - "logging=true"
     restart: always


### PR DESCRIPTION
## Description

Add timezone to mandataris service. This should fix issues with downloading mandatarissen.

## How to test

When you download a csv of mandatarissen, the start dates should now be correct. Before these dates were one day of because of the timezones.

## Links to other PR's

- https://github.com/lblod/mandataris-service/pull/110
