### PR TITLE
LMB-1238,1462 |Bump virutoso and sparql parser

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
     restart: always
     logging: *default-logging
   virtuoso:
-    image: redpencil/virtuoso:1.2.0-rc.1
+    image: redpencil/virtuoso:1.3.0-rc.1
     environment:
       SPARQL_UPDATE: "true"
       DEFAULT_GRAPH: "http://mu.semte.ch/application"


### PR DESCRIPTION
## Description

- virtuoso from `redpencil/virtuoso:1.2.0-rc.1` to `redpencil/virtuoso:1.3.0-rc.1`
- sparql-parser (database) from `semtech/sparql-parser:0.0.12` to `semtech/sparql-parser:0.0.14`

## How to test

  1. create checkpoint in virtuoso `drc exec -ti virtuoso isql-v` => `checkpoint;`
  2. copy the `/data/db` folder `APP-LMB> cp -r ./data ./data-before-virtuoso-bump`
  3. Follow these steps for upgrading https://github.com/redpencilio/docker-virtuoso/?tab=readme-ov-file#upgrading

## Links to other PR's

- /
