### PR TITLE
increase lisp heap size for sparql-parser

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       MU_SPARQL_ENDPOINT: "http://virtuoso:8890/sparql"
       DATABASE_OVERLOAD_RECOVERY: "true"
       DATABASE_COMPATIBILITY: "Virtuoso"
+      LISP_DYNAMIC_SPACE_SIZE: 4096
       # Note: not sure wether it gets picked up properly, it is meant for healing-process which may make
       # heavy queries
       QUERY_MAX_PROCESSING_TIME: 605000


### PR DESCRIPTION
## Description

the heap size of the sparql parser needs to be bumped because without this, queries that modify a lot of triples can sometimes cause out-of-memory errors
## How to test

does the app still run?