### PR TITLE
consume op data

### DIFF
--- a/config/migrations/2025/20250411151500-prep-op-consume/20250411151500-delete-bestuurseenheden.sparql
+++ b/config/migrations/2025/20250411151500-prep-op-consume/20250411151500-delete-bestuurseenheden.sparql
@@ -1,0 +1,22 @@
+  PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+  PREFIX org: <http://www.w3.org/ns/org#>
+  DELETE {
+    GRAPH ?g {
+      ?s ?p ?o.
+    }
+  }
+  WHERE {
+    graph ?g {
+      ?s a besluit:Bestuurseenheid.
+      ?s ?p ?o.
+      FILTER (?p NOT IN (
+                         ext:mailAdresVoorNotificaties,
+                         ext:voorbereidingVerborgen,
+                         ext:isLokaalBeheerd,
+                         ext:isOCMWVoor,
+                         org:linkedTo,
+                         ext:origineleBestuurseenheid
+                         ))
+    }
+  }

--- a/config/migrations/2025/20250411151500-prep-op-consume/20250411151501-delete-bestuursorganen.sparql
+++ b/config/migrations/2025/20250411151500-prep-op-consume/20250411151501-delete-bestuursorganen.sparql
@@ -1,0 +1,80 @@
+  PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+  PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
+  PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+  DELETE {
+    GRAPH ?g {
+      ?s ?p ?o.
+    }
+  }
+  WHERE {
+    ?s a besluit:Bestuursorgaan.
+    graph ?g {
+      ?s ?p ?o.
+    }
+    ?eenheid a besluit:Bestuurseenheid.
+    ?s mandaat:isTijdspecialisatieVan / besluit:bestuurt ?eenheid.
+    ?s besluit:classificatie ?clas.
+
+    FILTER(?clas IN (
+<http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/180a2fba-6ca9-4766-9b94-82006bb9c709>, # Gouverneur
+<http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d>, # Politieraad
+<http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4955bd72cd0e4eb895fdbfab08da0284>, # Burgemeester
+<http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000005>, # Gemeenteraad
+<http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000006>, # College van Burgemeester en Schepenen
+<http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000007>, # Raad voor Maatschappelijk Welzijn
+<http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000008>, # Vast Bureau
+<http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000009>, # Bijzonder Comité voor de Sociale Dienst
+<http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000a>, # Districtsraad
+<http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000b>, # Districtscollege
+<http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000c>, # Provincieraad
+<http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000d>, # Deputatie
+<http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/9314533e-891f-4d84-a492-0338af104065>, # Districtsburgemeester
+<http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/53c0d8cd-f3a2-411d-bece-4bd83ae2bbc9> # Voorzitter van het Bijzonder Comité voor de Sociale Dienst
+                          ))
+  FILTER( ?p NOT IN (
+                      lmb:deactivatedAt,
+                      ext:origineleBestuurseenheid,
+                      ext:isTijdelijkOrgaanIn,
+                      ext:origineleBestuursorgaan,
+                      lmb:heeftBestuursperiode
+                      ))
+};
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o.
+  }
+}
+WHERE {
+  ?s a besluit:Bestuursorgaan.
+  graph ?g {
+    ?s ?p ?o.
+  }
+  ?eenheid a besluit:Bestuurseenheid.
+  ?s besluit:bestuurt ?eenheid.
+  ?s besluit:classificatie ?clas.
+
+  FILTER(?clas IN (
+<http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/180a2fba-6ca9-4766-9b94-82006bb9c709>, # Gouverneur
+<http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d>, # Politieraad
+<http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4955bd72cd0e4eb895fdbfab08da0284>, # Burgemeester
+<http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000005>, # Gemeenteraad
+<http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000006>, # College van Burgemeester en Schepenen
+<http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000007>, # Raad voor Maatschappelijk Welzijn
+<http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000008>, # Vast Bureau
+<http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000009>, # Bijzonder Comité voor de Sociale Dienst
+<http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000a>, # Districtsraad
+<http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000b>, # Districtscollege
+<http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000c>, # Provincieraad
+<http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000d>, # Deputatie
+<http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/9314533e-891f-4d84-a492-0338af104065>, # Districtsburgemeester
+<http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/53c0d8cd-f3a2-411d-bece-4bd83ae2bbc9> # Voorzitter van het Bijzonder Comité voor de Sociale Dienst
+                        ))
+FILTER( ?p NOT IN (
+                    lmb:deactivatedAt,
+                    ext:origineleBestuurseenheid,
+                    ext:isTijdelijkOrgaanIn,
+                    ext:origineleBestuursorgaan,
+                    lmb:heeftBestuursperiode
+                    ))
+}

--- a/config/migrations/2025/20250411151500-prep-op-consume/20250411151502-delete-mandaten.sparql
+++ b/config/migrations/2025/20250411151500-prep-op-consume/20250411151502-delete-mandaten.sparql
@@ -1,0 +1,27 @@
+  PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+  PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
+  PREFIX org: <http://www.w3.org/ns/org#>
+  DELETE {
+    GRAPH ?g {
+      ?s ?p ?o.
+    }
+  }
+  WHERE {
+    ?s a mandaat:Mandaat.
+    graph ?g {
+      ?s ?p ?o.
+    }
+    FILTER(?p NOT IN (
+                      mandaat:aantalHouders,
+                      lmb:minAantalHouders
+                      ))
+    filter not exists {
+      VALUES ?role {
+        <http://data.lblod.info/id/lb-mandaat-classificatiecode/22da4572-4818-454b-bbd4-28a9ea97856c> # Voorzitter
+        <http://data.lblod.info/id/lb-mandaat-classificatiecode/28d0ed76-e1a3-4c90-89df-4d11587390b3> # Lid
+        <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/9210094bcdeb4fc8aabd458fe5a1d711> # Politieraadslid
+        <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/00801a4ba8104832a8430f014be9172f> # Voorzitter politieraad
+      }
+      ?s org:role ?role.
+    }
+  }

--- a/config/op-consumer/mapping/queries/README.md
+++ b/config/op-consumer/mapping/queries/README.md
@@ -1,0 +1,2 @@
+Example configuration for Organization Portal (PUBLIC) to Loket.
+It contains some mappings which are not used in the public producer (such as names of persons) but does not yet take all the necessary mapping into account yet for a sensitive data in OP. Mainly the pass configuration should be extended.

--- a/config/op-consumer/mapping/queries/README.md
+++ b/config/op-consumer/mapping/queries/README.md
@@ -1,2 +1,9 @@
-Example configuration for Organization Portal (PUBLIC) to Loket.
-It contains some mappings which are not used in the public producer (such as names of persons) but does not yet take all the necessary mapping into account yet for a sensitive data in OP. Mainly the pass configuration should be extended.
+Based off example configuration for Organization Portal (PUBLIC) to Loket.
+
+using this consumer, LMB consumes data from OP for realising its business case of tracking Mandataris instances, main targets for consumption are:
+
+- Bestuurseenheden
+- Bestuursorganen
+- Mandaten
+
+However, some other things are consumed as well: skos:Concepts, sites, locations.

--- a/config/op-consumer/mapping/queries/op2dl/identifier/identifier-kbo.rq
+++ b/config/op-consumer/mapping/queries/op2dl/identifier/identifier-kbo.rq
@@ -1,0 +1,25 @@
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+PREFIX persoon: <https://data.vlaanderen.be/ns/persoon#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+
+CONSTRUCT {
+  ?bestuurseenheid
+    ext:kbonummer ?kboNummer;
+    dcterms:identifier ?kboNummer.
+}
+WHERE {
+  ?identifier
+    skos:notation "KBO nummer";
+    generiek:gestructureerdeIdentificator ?gestructureerdeIdentificator.
+
+  ?gestructureerdeIdentificator
+    generiek:lokaleIdentificator ?kboNummer.
+
+  ?bestuurseenheid
+    adms:identifier ?identifier.
+}

--- a/config/op-consumer/mapping/queries/op2dl/identifier/identifier-ovo.rq
+++ b/config/op-consumer/mapping/queries/op2dl/identifier/identifier-ovo.rq
@@ -1,0 +1,20 @@
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+PREFIX skos:<http://www.w3.org/2004/02/skos/core#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+
+CONSTRUCT {
+  ?bestuurseenheid
+    dcterms:identifier ?ovoNummer.
+}
+WHERE {
+  ?identifier
+    skos:notation "OVO-nummer";
+    generiek:gestructureerdeIdentificator ?gestructureerdeIdentificator.
+
+  ?gestructureerdeIdentificator
+    generiek:lokaleIdentificator ?ovoNummer.
+
+  ?bestuurseenheid
+    adms:identifier ?identifier.
+}

--- a/config/op-consumer/mapping/queries/op2dl/mapping/bestuursorgaanLabel.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/mapping/bestuursorgaanLabel.sparql
@@ -1,0 +1,18 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX org: <http://www.w3.org/ns/org#>
+
+CONSTRUCT {
+  ?bestuursorgaan skos:prefLabel ?bestuursorgaanLabel.
+} WHERE {
+  ?bestuursorgaan
+    besluit:bestuurt ?bestuurseenheid;
+    org:classification ?classificatie.
+
+  ?classificatie
+    skos:prefLabel ?classificatieLabel.
+  ?bestuurseenheid
+    skos:prefLabel ?bestuurseenheidLabel.
+
+  BIND(CONCAT(str(?classificatieLabel), " ", str(?bestuurseenheidLabel)) as ?bestuursorgaanLabel)
+}

--- a/config/op-consumer/mapping/queries/op2dl/mapping/classification.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/mapping/classification.sparql
@@ -1,0 +1,15 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+CONSTRUCT {
+  ?s besluit:classificatie ?o .
+} WHERE {
+  ?s org:classification ?o .
+
+  # The consumers currently don't support the OCMWv subcategories, special mapping rules are needed.
+  # See mapping-ocmwv.sparql
+  FILTER (?o NOT IN
+    ( <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/34b5af85-dc9f-468f-9e03-ef89b174c267>,
+      <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9>
+    ))
+}

--- a/config/op-consumer/mapping/queries/op2dl/mapping/ext-bestuurseenheid-classificatie-code.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/mapping/ext-bestuurseenheid-classificatie-code.sparql
@@ -1,0 +1,5 @@
+CONSTRUCT {
+  ?s a <http://mu.semte.ch/vocabularies/ext/BestuurseenheidClassificatieCode>.
+} WHERE {
+  ?s a <http://lblod.data.gift/vocabularies/organisatie/BestuurseenheidClassificatieCode>.
+}

--- a/config/op-consumer/mapping/queries/op2dl/mapping/ext-representatief-orgaan-code.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/mapping/ext-representatief-orgaan-code.sparql
@@ -1,0 +1,5 @@
+CONSTRUCT {
+  ?s a <http://mu.semte.ch/vocabularies/ext/BestuurseenheidClassificatieCode>.
+} WHERE {
+  ?s a <http://mu.semte.ch/vocabularies/ext/RepresentatiefOrgaanClassificatieCode>.
+}

--- a/config/op-consumer/mapping/queries/op2dl/mapping/isTijdspecialisatieVan.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/mapping/isTijdspecialisatieVan.sparql
@@ -1,0 +1,8 @@
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+CONSTRUCT {
+  ?s mandaat:isTijdspecialisatieVan ?o.
+} WHERE {
+  ?s generiek:isTijdspecialisatieVan ?o.
+}

--- a/config/op-consumer/mapping/queries/op2dl/pass/pass-all-properties.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/pass/pass-all-properties.sparql
@@ -1,0 +1,21 @@
+CONSTRUCT {
+  ?s ?p ?o .
+}
+WHERE {
+  ?s ?p ?o .
+  FILTER EXISTS {
+    ?s a ?type .
+    VALUES ?type {
+      <http://lblod.data.gift/vocabularies/organisatie/BestuurseenheidClassificatieCode>
+      <http://lblod.data.gift/vocabularies/organisatie/BestuursorgaanClassificatieCode>
+      <http://lblod.data.gift/vocabularies/organisatie/OrganisatieStatusCode>
+      <http://lblod.data.gift/vocabularies/organisatie/TypeVestiging>
+      <http://mu.semte.ch/vocabularies/ext/BestuurseenheidClassificatieCode>
+      <http://mu.semte.ch/vocabularies/ext/BestuursorgaanClassificatieCode>
+      <http://mu.semte.ch/vocabularies/ext/OrganizationClassificationCode>
+      <http://www.w3.org/2004/02/skos/core#Concept>
+      <http://www.w3.org/ns/org#Site>
+      <http://www.w3.org/ns/prov#Location>
+    }
+  }
+}

--- a/config/op-consumer/mapping/queries/op2dl/pass/pass-without-identifier-or-classsification.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/pass/pass-without-identifier-or-classsification.sparql
@@ -1,0 +1,13 @@
+CONSTRUCT {
+  ?s ?p ?o .
+}
+WHERE {
+  ?s ?p ?o .
+  FILTER EXISTS {
+    ?s a ?type .
+    VALUES ?type {
+      <http://purl.org/dc/terms/Agent>
+    }
+  }
+  FILTER (?p NOT IN (<http://www.w3.org/ns/adms#identifier>, <http://www.w3.org/ns/org#classification>))
+}

--- a/config/op-consumer/mapping/queries/op2dl/pass/pass-without-lmb-properties.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/pass/pass-without-lmb-properties.sparql
@@ -26,6 +26,7 @@ WHERE {
     <http://mu.semte.ch/vocabularies/ext/origineleBestuursorgaan>,
     <http://lblod.data.gift/vocabularies/lmb/heeftBestuursperiode>,
     <http://data.vlaanderen.be/ns/mandaat#aantalHouders>, # <- this property on Mandaat is gone after initial load
-    <http://lblod.data.gift/vocabularies/lmb/minAantalHouders> # <- but this property remains on Mandaat
+    <http://lblod.data.gift/vocabularies/lmb/minAantalHouders>, # <- but this property remains on Mandaat
+    <http://mu.semte.ch/vocabularies/ext/deeltBestuurVan>
   ))
 }

--- a/config/op-consumer/mapping/queries/op2dl/pass/pass-without-lmb-properties.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/pass/pass-without-lmb-properties.sparql
@@ -1,0 +1,31 @@
+CONSTRUCT {
+  ?s ?p ?o .
+}
+WHERE {
+  ?s ?p ?o .
+  FILTER EXISTS {
+    ?s a ?type .
+    VALUES ?type {
+      <http://data.vlaanderen.be/ns/besluit#Bestuurseenheid>
+      <http://purl.org/dc/terms/Agent>
+      <http://www.w3.org/ns/org#Organization>
+      <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan>
+      <http://data.vlaanderen.be/ns/mandaat#Mandaat>
+      <http://www.w3.org/ns/org#Post>
+    }
+  }
+  FILTER (?p NOT IN (
+    <http://www.w3.org/ns/adms#identifier>,
+    <http://www.w3.org/ns/org#classification>,
+    <http://mu.semte.ch/vocabularies/ext/voorbereidingVerborgen>,
+    <http://mu.semte.ch/vocabularies/ext/isLokaalBeheerd>,
+    <http://mu.semte.ch/vocabularies/ext/isOCMWVoor>,
+    <http://www.w3.org/ns/org#linkedTo>,
+    <http://mu.semte.ch/vocabularies/ext/origineleBestuurseenheid>,
+    <http://mu.semte.ch/vocabularies/ext/isTijdelijkOrgaanIn>,
+    <http://mu.semte.ch/vocabularies/ext/origineleBestuursorgaan>,
+    <http://lblod.data.gift/vocabularies/lmb/heeftBestuursperiode>,
+    <http://data.vlaanderen.be/ns/mandaat#aantalHouders>, # <- this property on Mandaat is gone after initial load
+    <http://lblod.data.gift/vocabularies/lmb/minAantalHouders> # <- but this property remains on Mandaat
+  ))
+}

--- a/config/resources/external-besluit.lisp
+++ b/config/resources/external-besluit.lisp
@@ -40,12 +40,9 @@
   :class (s-prefix "besluit:Bestuurseenheid")
   :properties `((:naam :string ,(s-prefix "skos:prefLabel"))
                 (:alternatieve-naam :string-set ,(s-prefix "skos:altLabel"))
-                (:wil-mail-ontvangen :boolean ,(s-prefix "ext:wilMailOntvangen")) ;;Voorkeur in berichtencentrum
                 (:mail-adres :string ,(s-prefix "ext:mailAdresVoorNotificaties"))
-                (:is-trial-user :boolean ,(s-prefix "ext:isTrailUser"))
                 (:hide-legislatuur :boolean ,(s-prefix "ext:voorbereidingVerborgen"))
-                (:is-lokaal-beheerd :boolean ,(s-prefix "ext:isLokaalBeheerd"))
-                (:view-only-modules :string-set ,(s-prefix "ext:viewOnlyModules")))
+                (:is-lokaal-beheerd :boolean ,(s-prefix "ext:isLokaalBeheerd")))
   :has-one `((werkingsgebied :via ,(s-prefix "besluit:werkingsgebied")
                              :as "werkingsgebied")
              (werkingsgebied :via ,(s-prefix "ext:inProvincie")

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -128,3 +128,5 @@ services:
       LOG_ERRORS: true
   vendor-management-consumer:
     restart: "no"
+  op-public-consumer:
+    restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -346,3 +346,34 @@ services:
     volumes:
       - ./scripts/:/app/scripts/
     restart: "no"
+  op-public-consumer:
+    image: lblod/delta-consumer:0.1.4
+    environment:
+      DCR_SERVICE_NAME: "op-public-consumer"
+      # DCR_SYNC_BASE_URL: "https://organisaties.abb.lblod.info" # replace with link to OP API
+      DCR_SYNC_FILES_PATH: "/sync/public/files"
+      DCR_SYNC_DATASET_SUBJECT: "http://data.lblod.info/datasets/delta-producer/dumps/PublicCacheGraphDump"
+      DCR_INITIAL_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/initialSync/op-public"
+      DCR_DELTA_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/deltaSync/op-public"
+      DCR_JOB_CREATOR_URI: "http://data.lblod.info/services/id/op-public-consumer"
+      DCR_DISABLE_INITIAL_SYNC: "false"
+      DCR_WAIT_FOR_INITIAL_SYNC: "true"
+      DCR_KEEP_DELTA_FILES: "true"
+      DCR_START_FROM_DELTA_TIMESTAMP: "2025-01-01T00:00:00Z"
+      DCR_DELTA_JOBS_RETENTION_PERIOD: "30"
+      DCR_ENABLE_TRIPLE_REMAPPING: "true"
+      DCR_LANDING_ZONE_GRAPH: "http://mu.semte.ch/graphs/landing-zone/op-public"
+      DCR_REMAPPING_GRAPH: "http://mu.semte.ch/graphs/public"
+      DCR_BATCH_SIZE: 1000
+      SUDO_QUERY_RETRY_FOR_HTTP_STATUS_CODES: "404,500,503"
+      SUDO_QUERY_RETRY: "true"
+      DCR_SYNC_BASE_URL: "https://organisaties.abb.vlaanderen.be"
+      #DCR_CRON_PATTERN_DELTA_SYNC: '* * * * *' # this is every minute
+      DCR_DISABLE_DELTA_INGEST: "false"
+    volumes:
+      - ./config/op-consumer/mapping:/config/mapping
+      - ./data/files/consumer-files/op-public:/consumer-files/
+    restart: always
+    labels:
+      - "logging=true"
+    logging: *default-logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -350,7 +350,6 @@ services:
     image: lblod/delta-consumer:0.1.4
     environment:
       DCR_SERVICE_NAME: "op-public-consumer"
-      # DCR_SYNC_BASE_URL: "https://organisaties.abb.lblod.info" # replace with link to OP API
       DCR_SYNC_FILES_PATH: "/sync/public/files"
       DCR_SYNC_DATASET_SUBJECT: "http://data.lblod.info/datasets/delta-producer/dumps/PublicCacheGraphDump"
       DCR_INITIAL_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/initialSync/op-public"


### PR DESCRIPTION
## Description

add op public consumer, keep some predicates on our end as not yet implemented in op
## How to test

- update mandataris to match linked pr
- start the stack and let migrations run but don't start the op-public-consumer yet
- once migrations are ready, start op-public-consumer, this will run for a while (~10min)
- you're now up to date with op regarding the op data
- check if the main paths in the app still work (add/edit/update mandataris, reorder rangorde, ...) 
## Links to other PR's

- https://github.com/lblod/mandataris-service/pull/113
