### PR TITLE
remove nodebug profile from docker-compose.dev

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -75,14 +75,10 @@ services:
     restart: "no"
   mandataris:
     restart: "no"
-    profiles:
-      - nodebug
   concept-scheme:
     restart: "no"
   modified:
     restart: "no"
-    profiles:
-      - nodebug
   adressenregister:
     restart: "no"
   merge-person-cron:


### PR DESCRIPTION
## Description

Remove nodebug profile form docker-compose.dev
