### PR TITLE
publish beleidsdomein codes again

### DIFF
--- a/config/ldes-delta-pusher/ldes-instances.ts
+++ b/config/ldes-delta-pusher/ldes-instances.ts
@@ -35,6 +35,9 @@ export const ldesInstances = {
       "http://data.vlaanderen.be/ns/mandaat#Fractie": [
         "http://purl.org/dc/terms/modified",
       ],
+      "http://mu.semte.ch/vocabularies/ext/BeleidsdomeinCode": [
+        "http://purl.org/dc/terms/modified",
+      ],
       "http://www.w3.org/ns/org#Membership": {
         specialType: true,
         healingPredicates: ["http://purl.org/dc/terms/modified"],
@@ -104,6 +107,9 @@ export const ldesInstances = {
         instanceFilter: `?s <http://www.w3.org/ns/org#holds> / <http://www.w3.org/ns/org#role> / <http://mu.semte.ch/vocabularies/ext/publicMandate> "true"^^xsd:boolean .`,
       },
       "http://data.vlaanderen.be/ns/mandaat#Fractie": [
+        "http://purl.org/dc/terms/modified",
+      ],
+      "http://mu.semte.ch/vocabularies/ext/BeleidsdomeinCode": [
         "http://purl.org/dc/terms/modified",
       ],
       "http://www.w3.org/ns/org#Membership": {
@@ -184,6 +190,9 @@ export const ldesInstances = {
         healingPredicates: ["http://purl.org/dc/terms/modified"],
       },
       "http://data.vlaanderen.be/ns/mandaat#Fractie": [
+        "http://purl.org/dc/terms/modified",
+      ],
+      "http://mu.semte.ch/vocabularies/ext/BeleidsdomeinCode": [
         "http://purl.org/dc/terms/modified",
       ],
       "http://www.w3.org/ns/org#Membership": {
@@ -270,6 +279,10 @@ export const officialPredicates = {
     "http://www.w3.org/ns/org#linkedTo",
     "http://mu.semte.ch/vocabularies/ext/isFractietype",
     "http://mu.semte.ch/vocabularies/ext/geproduceerdDoor",
+  ],
+  "http://mu.semte.ch/vocabularies/ext/BeleidsdomeinCode": [
+    "http://www.w3.org/2004/02/skos/core#prefLabel",
+    "http://www.w3.org/2004/02/skos/core#inScheme",
   ],
   "http://www.w3.org/ns/org#Membership": [
     "http://www.w3.org/ns/org#organisation",

--- a/config/ldes-delta-pusher/ldes-instances.ts
+++ b/config/ldes-delta-pusher/ldes-instances.ts
@@ -283,6 +283,7 @@ export const officialPredicates = {
   "http://mu.semte.ch/vocabularies/ext/BeleidsdomeinCode": [
     "http://www.w3.org/2004/02/skos/core#prefLabel",
     "http://www.w3.org/2004/02/skos/core#inScheme",
+    "http://www.w3.org/ns/shacl#order",
   ],
   "http://www.w3.org/ns/org#Membership": [
     "http://www.w3.org/ns/org#organisation",


### PR DESCRIPTION
## Description

this publishes beleidsdomein codes (because users can create their own beleidsdomeincodes)

## How to test

add a beleidsdomein code, see that it is published in all streams

you also will want to check that you can republish all existing codes using the republish-ldes-data project script
to do that, run this query to get all codes:
```
  CONSTRUCT {
      ?s a <http://mu.semte.ch/vocabularies/ext/BeleidsdomeinCode>
    }WHERE {
    ?s a <http://mu.semte.ch/vocabularies/ext/BeleidsdomeinCode>
  }
```
add them to scripts/ldes-republish/data.ttl
then run `mu script project-scripts ldes-republish`
this will create about 720 page in each ldes feed containing the missing items immediately.
(this info was also added to a deploy task in jira so it happens in prod)
## Links to other PR's
you will need the fixes here to be able to add beleidsdomeincodes again
- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/565/files
