### PR TITLE
lmb-1515:  make person extra info roepnaam standard-string-input disp…

### DIFF
--- a/config/form-content/persoon-extra-info/form.ttl
+++ b/config/form-content/persoon-extra-info/form.ttl
@@ -2,6 +2,7 @@
 @prefix sh: <http://www.w3.org/ns/shacl#>.
 @prefix mu: <http://mu.semte.ch/vocabularies/core/>.
 @prefix displayTypes: <http://lblod.data.gift/display-types/>.
+@prefix lmbDisplayTypes: <http://lblod.data.gift/display-types/lmb/>.
 @prefix schema: <http://schema.org/>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>.
@@ -16,7 +17,7 @@
 
 ext:alternatieveNaamF
     a form:Field;
-    form:displayType displayTypes:defaultInput;
+    form:displayType lmbDisplayTypes:standard-string-input;
     sh:group ext:persoonExtraPG;
     sh:name "Roepnaam";
     sh:order 4;


### PR DESCRIPTION
## Description

Making the roepnaam field a standard-string-input displaytype so it can be shown in the editable field

## How to test

Go to the person extra info (person>detail + make sure the feature flag is on)

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/564
- https://github.com/lblod/form-content-service/pull/84
