### PR TITLE
LMB-1024 | Only publish tombstones of types that we add to the stream

### DIFF
--- a/config/ldes-delta-pusher/dispatch.ts
+++ b/config/ldes-delta-pusher/dispatch.ts
@@ -3,6 +3,7 @@ import { handleRegularTypes } from "./handle-regular-types";
 import { handleMandatarisType } from "./handle-mandataris-type";
 import { handleDecisionType } from "./handle-decision-type";
 import { handleMembershipType } from "./handle-membership-type";
+import { handleTombstoneType } from "./handle-tombstone-type";
 
 export default async function dispatch(changesets: Changeset[]) {
   const nonHistoryChangesets = filterOutNonAppChanges(changesets);
@@ -11,6 +12,7 @@ export default async function dispatch(changesets: Changeset[]) {
   handleMandatarisType(nonHistoryChangesets);
   handleDecisionType(nonHistoryChangesets);
   handleMembershipType(nonHistoryChangesets);
+  handleTombstoneType(nonHistoryChangesets);
 }
 
 function filterOutNonAppChanges(changesets: Changeset[]) {

--- a/config/ldes-delta-pusher/handle-tombstone-type.ts
+++ b/config/ldes-delta-pusher/handle-tombstone-type.ts
@@ -1,0 +1,48 @@
+import { Changeset } from "../types";
+import { sparqlEscapeUri } from "mu";
+
+import { publishInterestingSubjects } from "./handle-types-util";
+import { InterestingSubject, LDES_TYPE } from "./publisher";
+import { ldesInstances } from './ldes-instances';
+
+
+const typeValuesForStream = {
+  public: Object.keys(ldesInstances["public"].entities).map(uri => sparqlEscapeUri(uri)).join(' \n'),
+  abb: Object.keys(ldesInstances["abb"].entities).map(uri => sparqlEscapeUri(uri)).join(' \n'),
+  internal: Object.keys(ldesInstances["internal"].entities).map(uri => sparqlEscapeUri(uri)).join(' \n'),
+};
+
+const interestingSubjects = async (
+  subjects: string[]
+): Promise<InterestingSubject[]> => {
+  const filter = (stream: LDES_TYPE ) => {
+    return `
+      GRAPH ?g {
+        VALUES ?formerType { ${typeValuesForStream[stream]} }
+        ?s <http://www.w3.org/ns/activitystreams#formerType> ?formerType . 
+      }
+    `;
+  }
+
+  return subjects
+    .map((subject) => {
+      return {
+        uri: subject,
+        ldesType: {
+          public: {
+            filter: filter('public')
+          }, abb: {
+            filter: filter('abb')
+          }, internal: {
+            filter: filter('internal')
+          }
+        },
+        type: "http://www.w3.org/ns/activitystreams#Tombstone",
+      };
+    })
+};
+
+
+export const handleTombstoneType = async (changesets: Changeset[]) => {
+  await publishInterestingSubjects(changesets, interestingSubjects);
+};

--- a/config/ldes-delta-pusher/ldes-instances.ts
+++ b/config/ldes-delta-pusher/ldes-instances.ts
@@ -78,6 +78,7 @@ export const ldesInstances = {
         ],
       },
       "http://www.w3.org/ns/activitystreams#Tombstone": {
+        specialType: true,
         healingPredicates: ["http://purl.org/dc/terms/modified"],
         // 1) don't care about tombstones that are already present, modified date doesn't matter (old ones didn't have it)
         // 2) don't put tombstones for things that still have another type in another application graph
@@ -160,6 +161,7 @@ export const ldesInstances = {
         ],
       },
       "http://www.w3.org/ns/activitystreams#Tombstone": {
+        specialType: true,
         healingPredicates: ["http://purl.org/dc/terms/modified"],
         // 1) don't care about tombstones that are already present, modified date doesn't matter (old ones didn't have it)
         // 2) don't put tombstones for things that still have another type in another application graph
@@ -241,6 +243,7 @@ export const ldesInstances = {
         ],
       },
       "http://www.w3.org/ns/activitystreams#Tombstone": {
+        specialType: true,
         healingPredicates: ["http://purl.org/dc/terms/modified"],
         // 1) don't care about tombstones that are already present, modified date doesn't matter (old ones didn't have it)
         // 2) don't put tombstones for things that still have another type in another application graph


### PR DESCRIPTION
## Description

Now tombstones are being added to the ldes stream even if the type is not published on that stream. Nothing big but we do not want to add these tombstones to the streams.

## How to test

1. Comment an entity type from ONE stream in the `ldes-instances.ts` file (my example is a mandataris as i can easely remove that one)
2. Restart your app (or only the ldes-delta-pusher)
3. Remove through the frontend that type of entity
4. Follow the logs of the ldes-delta-pusher and the stream you commented the type in should not publish the tombstone

![image](https://github.com/user-attachments/assets/6a42d019-40a7-4a01-b099-96fca8488ee0)

The log should something like this (i removed some predicates from this)
```bash
ldes-delta-pusher-1  | DEBUG: [abb] Publishing data for subject http://data.lblod.info/id/mandatarissen/2ad2a6d4-5c03-42ae-82ff-f64da6e71d91:
ldes-delta-pusher-1  | 
ldes-delta-pusher-1  | DEBUG: [public] Publishing data for subject http://data.lblod.info/id/mandatarissen/2ad2a6d4-5c03-42ae-82ff-f64da6e71d91:
ldes-delta-pusher-1  | <http://data.lblod.info/id/mandatarissen/2ad2a6d4-5c03-42ae-82ff-f64da6e71d91> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/activitystreams#Tombstone> .
ldes-delta-pusher-1  | <http://data.lblod.info/id/mandatarissen/2ad2a6d4-5c03-42ae-82ff-f64da6e71d91> <http://www.w3.org/ns/activitystreams#formerType> <http://data.vlaanderen.be/ns/mandaat#Mandataris> .
ldes-delta-pusher-1  | DEBUG: [internal] Publishing data for subject http://data.lblod.info/id/mandatarissen/2ad2a6d4-5c03-42ae-82ff-f64da6e71d91:
ldes-delta-pusher-1  | <http://data.lblod.info/id/mandatarissen/2ad2a6d4-5c03-42ae-82ff-f64da6e71d91> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/activitystreams#Tombstone> .
ldes-delta-pusher-1  | <http://data.lblod.info/id/mandatarissen/2ad2a6d4-5c03-42ae-82ff-f64da6e71d91> <http://www.w3.org/ns/activitystreams#formerType> <http://data.vlaanderen.be/ns/mandaat#Mandataris> .
```