### PR TITLE
LMB-1681 | Custom url field

### DIFF
--- a/config/cl-authorization/config.lisp
+++ b/config/cl-authorization/config.lisp
@@ -136,6 +136,7 @@
   ("form:Field" -> _)
   ("form:ValidPhoneNumber" -> _)
   ("form:RequiredConstraint" -> _)
+  ("ext:ValidUri" -> _)
   ("lmb:Installatievergadering" -> _)
   ("lmb:InstallatievergaderingStatus" -> _)
   ("mandaat:RechtstreekseVerkiezing" -> _)

--- a/config/migrations/2025/20250709083400-add-url-as-custom-field.sparql
+++ b/config/migrations/2025/20250709083400-add-url-as-custom-field.sparql
@@ -13,7 +13,7 @@ INSERT DATA {
 
     ext:validUrlConstraint a ext:ValidUri ;
       form:grouping form:Bag ;
-      sh:resultMessage "Waarde zonder http://, https:// of mailto:// zijn niet toegestaan" .
+      sh:resultMessage "Zorg dat je waar begint met http://, https:// of mailto:" .
 
     <http://lblod.data.gift/display-types/lmb/custom-url-input> skos:inScheme <http://lblod.data.gift/concept-schemes/lmb-custom-display-types> .
   }

--- a/config/migrations/2025/20250709083400-add-url-as-custom-field.sparql
+++ b/config/migrations/2025/20250709083400-add-url-as-custom-field.sparql
@@ -13,7 +13,7 @@ INSERT DATA {
 
     ext:validUrlConstraint a ext:ValidUri ;
       form:grouping form:Bag ;
-      sh:resultMessage "Zorg dat je waar begint met http://, https:// of mailto:" .
+      sh:resultMessage "Zorg dat je waarde begint met http://, https:// of mailto:" .
 
     <http://lblod.data.gift/display-types/lmb/custom-url-input> skos:inScheme <http://lblod.data.gift/concept-schemes/lmb-custom-display-types> .
   }

--- a/config/migrations/2025/20250709083400-add-url-as-custom-field.sparql
+++ b/config/migrations/2025/20250709083400-add-url-as-custom-field.sparql
@@ -1,0 +1,20 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX form: <http://lblod.data.gift/vocabularies/forms/>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.data.gift/display-types/lmb/custom-url-input> a ext:DisplayType ;
+    mu:uuid "21199e3b-b99b-480f-9df7-9f98fb09339b" ;
+    form:validatedBy ext:validUrlConstraint ;    
+    skos:prefLabel "Link" .
+
+    ext:validUrlConstraint a ext:ValidUri ;
+      form:grouping form:Bag ;
+      sh:resultMessage "Waarde zonder http://, https:// of mailto:// zijn niet toegestaan" .
+
+    <http://lblod.data.gift/display-types/lmb/custom-url-input> skos:inScheme <http://lblod.data.gift/concept-schemes/lmb-custom-display-types> .
+  }
+}


### PR DESCRIPTION
## Description

Adding a new displaytype to thte database so we can add a url field to our custom forms. Note that this field has a validation added to it wihtout a path. This is handled in the form content service.

## How to test

1. run the migrations
2. Make sure the cache was cleared and test with togheter with the other PR's

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/593
- https://github.com/lblod/form-content-service/pull/88
