### PR TITLE
lmb-1679: create form extension for bestuursorganen

### DIFF
--- a/config/form-content/bestuursorgaan-extra-info/form.ttl
+++ b/config/form-content/bestuursorgaan-extra-info/form.ttl
@@ -1,0 +1,19 @@
+@prefix form: <http://lblod.data.gift/vocabularies/forms/> .
+@prefix sh: <http://www.w3.org/ns/shacl#>.
+@prefix mu: <http://mu.semte.ch/vocabularies/core/> .
+@prefix displayTypes: <http://lblod.data.gift/display-types/> .
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix besluit: <http://data.vlaanderen.be/ns/besluit#>.
+
+ext:editBestuursorgaanPG
+    a form:PropertyGroup; sh:name ""; sh:order 1.
+
+<http://data.lblod.info/id/lmb/forms/bestuursorgaan-extra-info>
+    a form:Form, form:TopLevelForm;
+    sh:group ext:editBestuursorgaanPG;
+    form:targetType besluit:Bestuursorgaan;
+    form:targetLabel skos:prefLabel;
+    ext:prefix <http://data.lblod.info/id/bestuursorganen/>;
+    ext:withHistory true;
+    mu:uuid "8a6c5084-fe88-4ddf-b3a7-2f596cbb2e39".


### PR DESCRIPTION
## Description

We want a form extension for a bestuursorgaan so organen can also add extra info. 

## How to test

1. Does the form include all the fields?
2. Run together with the frontend (make sure to restart your local form-content service to retrieve the form)

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/596
