### PR TITLE
lmb-1712 | Fix the xsd:date to be xsd:dateTime for mandataris start and einde

### DIFF
--- a/config/migrations/2025/20250728083100-cleanup-mandataris-start-einde-xsd-date-datatype/20250728083100-mandataris-start.sparql
+++ b/config/migrations/2025/20250728083100-cleanup-mandataris-start-einde-xsd-date-datatype/20250728083100-mandataris-start.sparql
@@ -15,11 +15,8 @@ WHERE {
   GRAPH ?g {
     ?mandataris a mandaat:Mandataris .
     ?mandataris mandaat:start ?start .
-
-    # the time should be an hour before so it is displayed correctly in the frontend
+   
     BIND(substr(str(?start), 1, 10) as ?startAsDateString)
-    BIND(bif:dateadd('hour', -1 ,strdt(?startAsDateString, xsd:date)) AS ?dayBefore)
-    BIND(substr(str(?dayBefore), 1, 10) as ?dayBeforeAsDateString)
-    BIND(strdt(CONCAT(?dayBeforeAsDateString, "T23:00:00Z"), xsd:dateTime) AS ?startWithTime)
+    BIND(strdt(CONCAT(?startAsDateString, "T00:00:00Z"), xsd:dateTime) AS ?startWithTime)
   }
 }

--- a/config/migrations/2025/20250728083100-cleanup-mandataris-start-einde-xsd-date-datatype/20250728083100-mandataris-start.sparql
+++ b/config/migrations/2025/20250728083100-cleanup-mandataris-start-einde-xsd-date-datatype/20250728083100-mandataris-start.sparql
@@ -1,22 +1,29 @@
 PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
 PREFIX org: <http://www.w3.org/ns/org#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX dct: <http://purl.org/dc/terms/>
+
 DELETE {
   GRAPH ?g {
     ?mandataris mandaat:start ?start .
+    ?mandataris dct:modified ?modified .
   }
 }
 INSERT {
   GRAPH ?g {
     ?mandataris mandaat:start ?startWithTime .
+    ?mandataris dct:modified ?now .
   }
 }
 WHERE {
   GRAPH ?g {
     ?mandataris a mandaat:Mandataris .
     ?mandataris mandaat:start ?start .
-   
+    OPTIONAL {
+      ?mandataris dct:modified ?modified .
+    }
     BIND(substr(str(?start), 1, 10) as ?startAsDateString)
     BIND(strdt(CONCAT(?startAsDateString, "T00:00:00Z"), xsd:dateTime) AS ?startWithTime)
+    BIND(NOW() as ?now)
   }
 }

--- a/config/migrations/2025/20250728083100-cleanup-mandataris-start-einde-xsd-date-datatype/20250728083100-mandataris-start.sparql
+++ b/config/migrations/2025/20250728083100-cleanup-mandataris-start-einde-xsd-date-datatype/20250728083100-mandataris-start.sparql
@@ -11,7 +11,7 @@ DELETE {
 }
 INSERT {
   GRAPH ?g {
-    ?mandataris mandaat:start ?startWithTime .
+    ?mandataris mandaat:start ?startDateTime .
     ?mandataris dct:modified ?now .
   }
 }
@@ -22,8 +22,27 @@ WHERE {
     OPTIONAL {
       ?mandataris dct:modified ?modified .
     }
-    BIND(substr(str(?start), 1, 10) as ?startAsDateString)
-    BIND(strdt(CONCAT(?startAsDateString, "T00:00:00Z"), xsd:dateTime) AS ?startWithTime)
-    BIND(NOW() as ?now)
+    FILTER(
+      datatype(?start) = xsd:date &&
+              ?start IN(
+                """2025-01-22"""^^xsd:date,
+                """2030-12-30"""^^xsd:date,
+                """2024-12-05"""^^xsd:date,
+                """2025-01-29"""^^xsd:date,
+                """2025-01-28"""^^xsd:date,
+                """2019-01-03"""^^xsd:date,
+                """2024-12-01"""^^xsd:date,
+                """2025-01-20"""^^xsd:date,
+                """2019-01-02"""^^xsd:date,
+                """2025-01-27"""^^xsd:date,
+                """2024-12-02"""^^xsd:date,
+                """2024-12-04"""^^xsd:date,
+                """2025-01-20"""^^xsd:date,                                                       
+                """2025-01-20T23:00:00.000Z"""^^xsd:date
+              ))
+      BIND(bif:dateadd('hour', """-1"""^^xsd:integer, strdt(substr(str(?start),1,10), xsd:date)) as ?daybefore)
+      BIND(substr(str(?daybefore), 1, 10) as ?startAsDateString)
+      BIND(strdt(CONCAT(?startAsDateString, "T23:00:00Z"), xsd:dateTime) AS ?startDateTime)
+      BIND(NOW() as ?now)
+    }
   }
-}

--- a/config/migrations/2025/20250728083100-cleanup-mandataris-start-einde-xsd-date-datatype/20250728083100-mandataris-start.sparql
+++ b/config/migrations/2025/20250728083100-cleanup-mandataris-start-einde-xsd-date-datatype/20250728083100-mandataris-start.sparql
@@ -15,7 +15,11 @@ WHERE {
   GRAPH ?g {
     ?mandataris a mandaat:Mandataris .
     ?mandataris mandaat:start ?start .
+
+    # the time should be an hour before so it is displayed correctly in the frontend
     BIND(substr(str(?start), 1, 10) as ?startAsDateString)
-    BIND(strdt(CONCAT(?startAsDateString, "T00:00:00Z"), xsd:dateTime) AS ?startWithTime)
+    BIND(bif:dateadd('hour', -1 ,strdt(?startAsDateString, xsd:date)) AS ?dayBefore)
+    BIND(substr(str(?dayBefore), 1, 10) as ?dayBeforeAsDateString)
+    BIND(strdt(CONCAT(?dayBeforeAsDateString, "T23:00:00Z"), xsd:dateTime) AS ?startWithTime)
   }
 }

--- a/config/migrations/2025/20250728083100-cleanup-mandataris-start-einde-xsd-date-datatype/20250728083100-mandataris-start.sparql
+++ b/config/migrations/2025/20250728083100-cleanup-mandataris-start-einde-xsd-date-datatype/20250728083100-mandataris-start.sparql
@@ -1,0 +1,21 @@
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+DELETE {
+  GRAPH ?g {
+    ?mandataris mandaat:start ?start .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?mandataris mandaat:start ?startWithTime .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?mandataris a mandaat:Mandataris .
+    ?mandataris mandaat:start ?start .
+    BIND(substr(str(?start), 1, 10) as ?startAsDateString)
+    BIND(strdt(CONCAT(?startAsDateString, "T00:00:00Z"), xsd:dateTime) AS ?startWithTime)
+  }
+}

--- a/config/migrations/2025/20250728083100-cleanup-mandataris-start-einde-xsd-date-datatype/20250728083101-mandataris-einde.sparql
+++ b/config/migrations/2025/20250728083100-cleanup-mandataris-start-einde-xsd-date-datatype/20250728083101-mandataris-einde.sparql
@@ -11,7 +11,7 @@ DELETE {
 }
 INSERT {
   GRAPH ?g {
-    ?mandataris mandaat:einde ?eindeWithTime .
+    ?mandataris mandaat:einde ?eindeDateTime .
     ?mandataris dct:modified ?now .
   }
 }
@@ -22,8 +22,26 @@ WHERE {
     OPTIONAL {
       ?mandataris dct:modified ?modified .
     }
+    FILTER(
+            datatype(?einde) = xsd:date &&
+                    ?einde IN(
+                      """2025-01-22"""^^xsd:date,
+                      """2030-12-30"""^^xsd:date,
+                      """2024-12-05"""^^xsd:date,
+                      """2025-01-29"""^^xsd:date,
+                      """2025-01-28"""^^xsd:date,
+                      """2019-01-03"""^^xsd:date,
+                      """2024-12-01"""^^xsd:date,
+                      """2025-01-20"""^^xsd:date,
+                      """2019-01-02"""^^xsd:date,
+                      """2025-01-27"""^^xsd:date,
+                      """2024-12-02"""^^xsd:date,
+                      """2024-12-04"""^^xsd:date,
+                      """2025-01-20"""^^xsd:date,                                                       
+                      """2025-01-20T23:00:00.000Z"""^^xsd:date
+                    ))
     BIND(substr(str(?einde), 1, 10) as ?eindeAsDateString)
-    BIND(strdt(CONCAT(?eindeAsDateString, "T23:59:59Z"), xsd:dateTime) AS ?eindeWithTime)
+    BIND(strdt(CONCAT(?eindeAsDateString, "T22:59:59Z"), xsd:dateTime) AS ?eindeDateTime)
     BIND(NOW() as ?now)
   }
-} 
+}

--- a/config/migrations/2025/20250728083100-cleanup-mandataris-start-einde-xsd-date-datatype/20250728083101-mandataris-einde.sparql
+++ b/config/migrations/2025/20250728083100-cleanup-mandataris-start-einde-xsd-date-datatype/20250728083101-mandataris-einde.sparql
@@ -17,6 +17,6 @@ WHERE {
     ?mandataris a mandaat:Mandataris .
     ?mandataris mandaat:einde ?einde .
     BIND(substr(str(?einde), 1, 10) as ?eindeAsDateString)
-    BIND(strdt(CONCAT(?eindeAsDateString, "T22:59:59Z"), xsd:dateTime) AS ?eindeWithTime) # changed so the frontend shows the date with hours 23:59:59
+    BIND(strdt(CONCAT(?eindeAsDateString, "T23:59:59Z"), xsd:dateTime) AS ?eindeWithTime)
   }
 } 

--- a/config/migrations/2025/20250728083100-cleanup-mandataris-start-einde-xsd-date-datatype/20250728083101-mandataris-einde.sparql
+++ b/config/migrations/2025/20250728083100-cleanup-mandataris-start-einde-xsd-date-datatype/20250728083101-mandataris-einde.sparql
@@ -1,22 +1,29 @@
 PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
 PREFIX org: <http://www.w3.org/ns/org#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX dct: <http://purl.org/dc/terms/>
 
 DELETE {
   GRAPH ?g {
     ?mandataris mandaat:einde ?einde .
+    ?mandataris dct:modified ?modified .
   }
 }
 INSERT {
   GRAPH ?g {
     ?mandataris mandaat:einde ?eindeWithTime .
+    ?mandataris dct:modified ?now .
   }
 }
 WHERE {
   GRAPH ?g {
     ?mandataris a mandaat:Mandataris .
     ?mandataris mandaat:einde ?einde .
+    OPTIONAL {
+      ?mandataris dct:modified ?modified .
+    }
     BIND(substr(str(?einde), 1, 10) as ?eindeAsDateString)
     BIND(strdt(CONCAT(?eindeAsDateString, "T23:59:59Z"), xsd:dateTime) AS ?eindeWithTime)
+    BIND(NOW() as ?now)
   }
 } 

--- a/config/migrations/2025/20250728083100-cleanup-mandataris-start-einde-xsd-date-datatype/20250728083101-mandataris-einde.sparql
+++ b/config/migrations/2025/20250728083100-cleanup-mandataris-start-einde-xsd-date-datatype/20250728083101-mandataris-einde.sparql
@@ -1,0 +1,22 @@
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+DELETE {
+  GRAPH ?g {
+    ?mandataris mandaat:einde ?einde .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?mandataris mandaat:einde ?eindeWithTime .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?mandataris a mandaat:Mandataris .
+    ?mandataris mandaat:einde ?einde .
+    BIND(substr(str(?einde), 1, 10) as ?eindeAsDateString)
+    BIND(strdt(CONCAT(?eindeAsDateString, "T23:59:59Z"), xsd:dateTime) AS ?eindeWithTime)
+  }
+} 

--- a/config/migrations/2025/20250728083100-cleanup-mandataris-start-einde-xsd-date-datatype/20250728083101-mandataris-einde.sparql
+++ b/config/migrations/2025/20250728083100-cleanup-mandataris-start-einde-xsd-date-datatype/20250728083101-mandataris-einde.sparql
@@ -17,6 +17,6 @@ WHERE {
     ?mandataris a mandaat:Mandataris .
     ?mandataris mandaat:einde ?einde .
     BIND(substr(str(?einde), 1, 10) as ?eindeAsDateString)
-    BIND(strdt(CONCAT(?eindeAsDateString, "T23:59:59Z"), xsd:dateTime) AS ?eindeWithTime)
+    BIND(strdt(CONCAT(?eindeAsDateString, "T22:59:59Z"), xsd:dateTime) AS ?eindeWithTime) # changed so the frontend shows the date with hours 23:59:59
   }
 } 


### PR DESCRIPTION
## Description

The domain says that the datatype of `mandaat:start` and `mandaat:einde` should be `xsd:dateTime` and not `xsd:Date`.

1. create the migrations  => directly correct the time to be correctly (start and end -of day)
2. Have a look at the non mandataris types and why they get the xsd:date datatype

## How to test

1. Check the count of xsd:date datatypes for a mandataris
```sparql
  PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
  PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
  PREFIX org: <http://www.w3.org/ns/org#>
  PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>

  SELECT DISTINCT ?type ?predicate COUNT(?object) AS ?count
  WHERE {
    GRAPH ?g {
      VALUES ?predicate {
        mandaat:start
        mandaat:einde
      }
      ?subject a ?type .
      ?subject ?predicate ?object .

      FILTER(datatype(?object) = xsd:date)
    }
  } GROUP BY ?predicate ?type

```
2. Run the mirgations
3.  Count should be zero for both predicates of a mandataris

One mandataris was in OCMW Kruibeke
- http://localhost:4200/mandatarissen/312230d1-96ef-454c-a8c9-3036fccb537c/persoon/3793478434ed690112585d86858c7dc45d0663d8c66afc1fb0f4e503fe54dcd9/mandataris
- The date should still show the same as before (so check it before the migration first) and the time should be at the end and the beginning of the day

<img width="1078" height="806" alt="image" src="https://github.com/user-attachments/assets/fbbc0b30-e0db-45c1-bdbb-b4b975ac8045" />


query i used to get the dates for the migration
```sparql
  PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
  PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
  PREFIX org: <http://www.w3.org/ns/org#>
  PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>

  PREFIX dct: <http://purl.org/dc/terms/>
  SELECT DISTINCT ?object 
  WHERE {
    GRAPH ?g {
      VALUES ?predicate {
        mandaat:start
        mandaat:einde
      }
      ?subject a ?type .
      ?subject ?predicate ?object .
      ?subject dct:modified ?mod .

      FILTER(datatype(?object) = xsd:date)
    }
  }
  ORDER BY DESC(?mod)
  LIMIT 100

```

## Links to other PR's

- /

## Attachments

**Result of inital count for the datatype**
```org
| type                                                          | predicate                                  | count |
|---------------------------------------------------------------+--------------------------------------------+-------|
| http://data.vlaanderen.be/ns/mandaat#Mandataris               | http://data.vlaanderen.be/ns/mandaat#einde |  2352 |
| http://data.vlaanderen.be/ns/mandaat#Mandataris               | http://data.vlaanderen.be/ns/mandaat#start |    52 |
| http://data.lblod.info/vocabularies/contacthub/AgentInPositie | http://data.vlaanderen.be/ns/mandaat#einde |   357 |

```