### PR TITLE
lmb-1297 | persons without election data

### DIFF
--- a/config/migrations/2025/20250808100000-expose-verkiezingen-to-ocmw/20250808100001-copy-verkiezingen.sparql
+++ b/config/migrations/2025/20250808100000-expose-verkiezingen-to-ocmw/20250808100001-copy-verkiezingen.sparql
@@ -1,0 +1,30 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX org: <http://www.w3.org/ns/org#>
+INSERT {
+  GRAPH ?ocmwG {
+    ?verkiezing mandaat:steltSamen ?gemeenteOrgInTijd.
+    ?verkiezing ext:copiedForOCMW ?ocmw.
+    ?verkiezing mandaat:steltSamen ?ocmwOrgInTijd.
+  }
+} WHERE {
+  VALUES ?gemeente {
+    <http://data.lblod.info/id/bestuurseenheden/dfd76f1550853dc2b4bc8d763c7b378c8c8c81588dd4ba3e0ef05cfd0a456927> # Herstappe
+    <http://data.lblod.info/id/bestuurseenheden/1086df7c6c150e427fc56e2239eed2b7e2d9d4a97abb24c00e951ec89f9bcbec> # Lo-Reninge
+  } 
+  ?gemeente a besluit:Bestuurseenheid .
+  ?ocmw a besluit:Bestuurseenheid .
+  ?gemeente skos:prefLabel ?name.
+  ?ocmw skos:prefLabel ?name.
+  ?gemeenteOrgInTijd mandaat:isTijdspecialisatieVan / besluit:bestuurt ?gemeente.
+  ?gemeenteOrgInTijd lmb:heeftBestuursperiode <http://data.lblod.info/id/concept/Bestuursperiode/96efb929-5d83-48fa-bfbb-b98dfb1180c7> .
+    ?ocmwOrg besluit:bestuurt ?ocmw.
+    ?ocmwOrg besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000007> .
+    ?ocmwOrgInTijd mandaat:isTijdspecialisatieVan ?ocmwOrg.
+    ?ocmwOrgInTijd lmb:heeftBestuursperiode <http://data.lblod.info/id/concept/Bestuursperiode/96efb929-5d83-48fa-bfbb-b98dfb1180c7> .
+      ?ocmwG ext:ownedBy ?ocmw .
+  ?verkiezing mandaat:steltSamen ?gemeenteOrgInTijd.
+}

--- a/config/migrations/2025/20250808100000-expose-verkiezingen-to-ocmw/20250808100002-copy-verkiezing-data.sparql
+++ b/config/migrations/2025/20250808100000-expose-verkiezingen-to-ocmw/20250808100002-copy-verkiezing-data.sparql
@@ -1,0 +1,20 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+INSERT {
+  GRAPH ?ocmwG {
+    ?verkiezing ?vp ?vo.
+  }
+} WHERE {
+  VALUES ?ocmwG {
+    <http://mu.semte.ch/graphs/organizations/d7dd13304150f5fe65bd239093ef08dfae107864d26299ac91240a88782aed54/LoketLB-mandaatGebruiker> # Herstappe
+    <http://mu.semte.ch/graphs/organizations/5bcbe1dcc6bd42354ce05e87c56a09a0e62c2fb67a4e6def59a30d40b1d70e4b/LoketLB-mandaatGebruiker> # Lo-Reninge
+  }
+  GRAPH ?ocmwG {
+    ?verkiezing mandaat:steltSamen ?gemeenteOrgInTijd.
+    ?verkiezing ext:copiedForOCMW ?ocmw.
+  }
+  ?verkiezing ?vp ?vo.
+}

--- a/config/migrations/2025/20250808100000-expose-verkiezingen-to-ocmw/20250808100003-copy-kieslijsten.sparql
+++ b/config/migrations/2025/20250808100000-expose-verkiezingen-to-ocmw/20250808100003-copy-kieslijsten.sparql
@@ -1,0 +1,21 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+INSERT {
+  GRAPH ?ocmwG {
+    ?lijst ?lp ?lo.
+  }
+} WHERE {
+  VALUES ?ocmwG {
+    <http://mu.semte.ch/graphs/organizations/d7dd13304150f5fe65bd239093ef08dfae107864d26299ac91240a88782aed54/LoketLB-mandaatGebruiker> # Herstappe
+    <http://mu.semte.ch/graphs/organizations/5bcbe1dcc6bd42354ce05e87c56a09a0e62c2fb67a4e6def59a30d40b1d70e4b/LoketLB-mandaatGebruiker> # Lo-Reninge
+  }
+  GRAPH ?ocmwG {
+    ?verkiezing mandaat:steltSamen ?gemeenteOrgInTijd.
+    ?verkiezing ext:copiedForOCMW ?ocmw.
+  }
+  ?lijst mandaat:behoortTot ?verkiezing.
+  ?lijst ?lp ?lo.
+}

--- a/config/migrations/2025/20250808100000-expose-verkiezingen-to-ocmw/20250808100004-copy-results.sparql
+++ b/config/migrations/2025/20250808100000-expose-verkiezingen-to-ocmw/20250808100004-copy-results.sparql
@@ -1,0 +1,22 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+INSERT {
+  GRAPH ?ocmwG {
+    ?res ?rp ?ro.
+  }
+} WHERE {
+  VALUES ?ocmwG {
+    <http://mu.semte.ch/graphs/organizations/d7dd13304150f5fe65bd239093ef08dfae107864d26299ac91240a88782aed54/LoketLB-mandaatGebruiker> # Herstappe
+    <http://mu.semte.ch/graphs/organizations/5bcbe1dcc6bd42354ce05e87c56a09a0e62c2fb67a4e6def59a30d40b1d70e4b/LoketLB-mandaatGebruiker> # Lo-Reninge
+  }
+  GRAPH ?ocmwG {
+    ?verkiezing mandaat:steltSamen ?gemeenteOrgInTijd.
+    ?verkiezing ext:copiedForOCMW ?ocmw.
+    ?lijst mandaat:behoortTot ?verkiezing.
+  }
+  ?res mandaat:isResultaatVoor ?lijst.
+  ?res ?rp ?ro.
+}

--- a/config/migrations/2025/20250808100000-expose-verkiezingen-to-ocmw/20250808100005-copy-persons.sparql
+++ b/config/migrations/2025/20250808100000-expose-verkiezingen-to-ocmw/20250808100005-copy-persons.sparql
@@ -1,0 +1,22 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+INSERT {
+  GRAPH ?ocmwG {
+    ?persoon ?p ?o.
+  }
+} WHERE {
+  VALUES ?ocmwG {
+    <http://mu.semte.ch/graphs/organizations/d7dd13304150f5fe65bd239093ef08dfae107864d26299ac91240a88782aed54/LoketLB-mandaatGebruiker> # Herstappe
+    <http://mu.semte.ch/graphs/organizations/5bcbe1dcc6bd42354ce05e87c56a09a0e62c2fb67a4e6def59a30d40b1d70e4b/LoketLB-mandaatGebruiker> # Lo-Reninge
+  }
+  GRAPH ?ocmwG {
+    ?verkiezing ext:copiedForOCMW ?ocmw.
+    ?lijst mandaat:behoortTot ?verkiezing.
+    ?res mandaat:isResultaatVoor ?lijst.
+    ?res mandaat:isResultaatVan ?persoon.
+  }
+  ?persoon ?p ?o.
+}

--- a/config/migrations/2025/20250808100000-expose-verkiezingen-to-ocmw/20250808100006-copy-person-data.sparql
+++ b/config/migrations/2025/20250808100000-expose-verkiezingen-to-ocmw/20250808100006-copy-person-data.sparql
@@ -1,0 +1,29 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
+INSERT {
+  GRAPH ?ocmwG {
+    ?target ?p ?o.
+  }
+} WHERE {
+  VALUES ?ocmwG {
+    <http://mu.semte.ch/graphs/organizations/d7dd13304150f5fe65bd239093ef08dfae107864d26299ac91240a88782aed54/LoketLB-mandaatGebruiker> # Herstappe
+    <http://mu.semte.ch/graphs/organizations/5bcbe1dcc6bd42354ce05e87c56a09a0e62c2fb67a4e6def59a30d40b1d70e4b/LoketLB-mandaatGebruiker> # Lo-Reninge
+  }
+  GRAPH ?ocmwG {
+    ?verkiezing ext:copiedForOCMW ?ocmw.
+    ?lijst mandaat:behoortTot ?verkiezing.
+    ?res mandaat:isResultaatVoor ?lijst.
+    ?res mandaat:isResultaatVan ?persoon.
+    VALUES ?linkP {
+      adms:identifier
+      persoon:heeftGeboorte
+    }
+    ?persoon ?linkP ?target.
+  }
+  ?target ?p ?o.
+}


### PR DESCRIPTION
## Description

Some persons are not linked to the election data for Herstappe and Lo-Reninge.

## How to test

Test with this query  first
```sparql
  PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
  PREFIX bestuursperiode: <http://data.lblod.info/id/concept/Bestuursperiode/>
  PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
  PREFIX person: <http://www.w3.org/ns/person#>
  PREFIX org: <http://www.w3.org/ns/org#>
  PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
  PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
  PREFIX foaf: <http://xmlns.com/foaf/0.1/>
  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>

  #SELECT COUNT(DISTINCT ?person) AS ?count
  SELECT DISTINCT ?person ?fName ?lName ?verkiezingsresultaat ?bestuursorgaanLabel
    WHERE {
      VALUES ?gemeenteraadRole {
        <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000015> # Lid RMW
        <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000011> # Lid Gemeenteraad
      }
      GRAPH ?g {
        ?person foaf:familyName ?lName .
        ?person persoon:gebruikteVoornaam ?fName .
        ?person ^mandaat:isBestuurlijkeAliasVan ?mandataris .

        ?mandataris org:holds ?mandaat .

        FILTER NOT EXISTS {
          ?person ^mandaat:isResultaatVan ?verkiezingsResultaat .
        }
      }
      ?bestuursorgaanIT mandaat:isTijdspecialisatieVan / skos:prefLabel ?bestuursorgaanLabel .
      ?bestuursorgaanIT lmb:heeftBestuursperiode bestuursperiode:96efb929-5d83-48fa-bfbb-b98dfb1180c7 . # bestuursperiode 2025 - heden
      ?bestuursorgaanIT org:hasPost ?mandaat .
      ?mandaat org:role ?gemeenteraadRole .
      ?g ext:ownedBy ?eenheid .
    }
    ORDER BY ?fName

```

After you now run the migrations it should return no results
