### PR TITLE
LMB-1769 | Remove "voorzitter" organen

### DIFF
--- a/config/migrations/2025/20250930133000-remove-voorzitter-organen.sparql
+++ b/config/migrations/2025/20250930133000-remove-voorzitter-organen.sparql
@@ -1,0 +1,23 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+DELETE {
+  GRAPH ?g {
+    ?bestuursorgaan besluit:classificatie ?notAllowed .
+    ?bestuursorgaan ?p ?o .
+    ?boi <https://data.vlaanderen.be/ns/generiek#isTijdspecialisatieVan> ?bestuursorgaan .
+    ?boi ?pp ?oo .
+  }
+}
+WHERE {
+  VALUES ?notAllowed {
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/e14fe683-e061-44a2-b7c8-e10cab4e6ed9> # Voorzitter RMW
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4c38734d-2cc1-4d33-b792-0bd493ae9fc2> # Voorzitter GR
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/53c0d8cd-f3a2-411d-bece-4bd83ae2bbc9> # Voorzitter BCSD
+  }
+  GRAPH ?g {
+    ?bestuursorgaan besluit:classificatie ?notAllowed .
+    ?bestuursorgaan ?p ?o .
+    ?boi <https://data.vlaanderen.be/ns/generiek#isTijdspecialisatieVan> ?bestuursorgaan .
+    ?boi ?pp ?oo .
+  }
+}

--- a/config/op-consumer/mapping/queries/README.md
+++ b/config/op-consumer/mapping/queries/README.md
@@ -1,9 +1,17 @@
 Based off example configuration for Organization Portal (PUBLIC) to Loket.
 
-using this consumer, LMB consumes data from OP for realising its business case of tracking Mandataris instances, main targets for consumption are:
+using this consumer, LMB consumes data from OP for realizing its business case of tracking Mandataris instances, main targets for consumption are:
 
 - Bestuurseenheden
 - Bestuursorganen
 - Mandaten
 
 However, some other things are consumed as well: skos:Concepts, sites, locations.
+
+## Bestuursorganen
+
+We are inserting all bestuursorganen coming from OP. The predicates of these bestuursorganen are filtered so they do not override or remove the ones we add in Lokaal Mandatenbeheer.
+
+> NOTE
+> september 2025
+> We are seeing "Voorzitter van..." bestuursorganenInTijd these organen are creating bugs in the application. Because we are not using them in the application we can ignore them when they are fetched by the OP-consumer 

--- a/config/op-consumer/mapping/queries/op2dl/pass/pass-without-voorzitter-bestuursorgaan-codes.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/pass/pass-without-voorzitter-bestuursorgaan-codes.sparql
@@ -1,20 +1,22 @@
 CONSTRUCT {
-  ?s ?p ?o .
+  ?bestuursorgaan ?p ?o .
+  ?bestuursorgaan <http://data.vlaanderen.be/ns/besluit#classificatie> ?classificationCode .
 }
 WHERE {
-  ?s ?p ?o .
-  FILTER EXISTS {
-    ?s a ?type .
-    VALUES ?type {
-      <http://data.vlaanderen.be/ns/besluit#Bestuurseenheid>
-      <http://purl.org/dc/terms/Agent>
-      <http://www.w3.org/ns/org#Organization>
-      <http://data.vlaanderen.be/ns/mandaat#Mandaat>
-      <http://www.w3.org/ns/org#Post>
-    }
-  }
-  # These properties should be the same in file 'pass-without-voorzitter-bestuursorgaan-codes.sparql'
+  ?bestuursorgaan a <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan> .
+  ?bestuursorgaan <http://data.vlaanderen.be/ns/besluit#classificatie> ?classificationCode .
+  ?bestuursorgaan ?p ?o .
+
+  FILTER(?classificationCode NOT IN(
+      <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/e14fe683-e061-44a2-b7c8-e10cab4e6ed9>, # Voorzitter RMW 
+      <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4c38734d-2cc1-4d33-b792-0bd493ae9fc2>, # Voorzitter GR 
+      <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/53c0d8cd-f3a2-411d-bece-4bd83ae2bbc9> # Voorzitter BCSD 
+    )
+  )
+
+  # Got these properties from file 'pass-without-lmb-properties.sparql'
   FILTER (?p NOT IN (
+    <http://data.vlaanderen.be/ns/besluit#classificatie>, # Not an LMB property added this for only this query
     <http://www.w3.org/ns/adms#identifier>,
     <http://www.w3.org/ns/org#classification>,
     <http://mu.semte.ch/vocabularies/ext/voorbereidingVerborgen>,
@@ -33,3 +35,4 @@ WHERE {
     <http://data.vlaanderen.be/ns/mandaat#bindingEinde> # are set by the first mandataris start date in the period
   ))
 }
+


### PR DESCRIPTION
## Description

Some of our mandatarissen are getting a link to the "voorzitter" orgaan. This is not an orgaan dat we support in our application. Ignore them when consuming the OP-consumer and remove all current usage.

## How to test

1. Run the op-consumer
2. Run the migration
3. When hgoing to the frontend localhost:90 all voorzitters for bcsd will not have a second orgaan anymore
