### PR TITLE
LMB-1614 | Local deployment aalst

### DIFF
--- a/config/authorization-wrapper/router.js
+++ b/config/authorization-wrapper/router.js
@@ -1,4 +1,4 @@
 export const router = {
-  "/abb": "http://ldes-backend:80",
-  "/internal": "http://ldes-backend:80",
+  "/abb": "https://mandatenbeheer.lblod.info/streams/ldes/abb",
+  "/internal": "https://mandatenbeheer.lblod.info/streams/ldes/internal",
 };

--- a/config/bb-aalst-ldes/config.ts
+++ b/config/bb-aalst-ldes/config.ts
@@ -1,24 +1,14 @@
-import {
-  LDES_BASE,
-  FIRST_PAGE,
-  TARGET_GRAPH,
-  STATUS_GRAPH,
-  EXTRA_HEADERS,
-  VERSION_PREDICATE,
-  TIME_PREDICATE,
-} from "../environment";
-
 export default {
   endpoints: [
     {
       name: "Public Stream",
-      LDES_BASE,
-      FIRST_PAGE,
-      TARGET_GRAPH,
-      STATUS_GRAPH,
-      EXTRA_HEADERS,
-      VERSION_PREDICATE,
-      TIME_PREDICATE,
+      LDES_BASE: process.env.LDES_BASE,
+      FIRST_PAGE: process.env.FIRST_PAGE,
+      TARGET_GRAPH: process.env.TARGET_GRAPH,
+      STATUS_GRAPH: process.env.STATUS_GRAPH,
+      EXTRA_HEADERS: process.env.EXTRA_HEADERS,
+      VERSION_PREDICATE: process.env.VERSION_PREDICATE,
+      TIME_PREDICATE: process.env.TIME_PREDICATE,
     },
   ],
 };

--- a/config/bb-aalst-ldes/config.ts
+++ b/config/bb-aalst-ldes/config.ts
@@ -1,0 +1,24 @@
+import {
+  LDES_BASE,
+  FIRST_PAGE,
+  TARGET_GRAPH,
+  STATUS_GRAPH,
+  EXTRA_HEADERS,
+  VERSION_PREDICATE,
+  TIME_PREDICATE,
+} from "../environment";
+
+export default {
+  endpoints: [
+    {
+      name: "Public Stream",
+      LDES_BASE,
+      FIRST_PAGE,
+      TARGET_GRAPH,
+      STATUS_GRAPH,
+      EXTRA_HEADERS,
+      VERSION_PREDICATE,
+      TIME_PREDICATE,
+    },
+  ],
+};

--- a/config/bb-aalst-ldes/processPage.ts
+++ b/config/bb-aalst-ldes/processPage.ts
@@ -1,5 +1,5 @@
 import { logger } from "../logger";
-import { updateSudo } from "@lblod/mu-auth-sudo";
+import { updateSudo, querySudo } from "@lblod/mu-auth-sudo";
 import { sparqlEscapeUri } from "mu";
 import {
   BATCH_GRAPH,
@@ -27,18 +27,15 @@ export async function processPage() {
 
   const burgemeesterOrgaanClassificatieCodeUri = 'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4955bd72cd0e4eb895fdbfab08da0284';
   const bekrachtigdPublicatieCodeUri = 'http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/9d8fd14d-95d0-4f5e-b3a5-a56a126227b6';
-
-  await updateSudo(`
+  const commonWhereStatement = (selection: string) => `
     PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
     PREFIX org: <http://www.w3.org/ns/org#>
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
     PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
-    INSERT {
-      GRAPH ?organizationG {
-        ?s ?pNew ?oNew.
-      }
-    } WHERE {
+
+    ${selection}
+    WHERE {
       VALUES ?bestuurseenheid { ${sparqlEscapeUri(GEMEENTE_BESTUURSEENHEID_URI)} }
       
       ?orgaanIT org:hasPost ?mandaat .
@@ -63,5 +60,22 @@ export async function processPage() {
         ?versionedMember ?pNew ?oNew .
         FILTER (?pNew NOT IN ( ${sparqlEscapeUri(VERSION_PREDICATE)}, ${sparqlEscapeUri(TIME_PREDICATE)} ))
       }
-    }`);
+    }
+    `
+
+  const sparqlResult = await querySudo(commonWhereStatement('SELECT DISTINCT ?s'));
+  const foundSubjectUris = sparqlResult.results?.bindings.map((b) => b.s.value) ?? [];
+  if (foundSubjectUris.length >= 1) {
+    logger.info(`Found ${foundSubjectUris.length} subjects for burgemeester-benoemingen. (${foundSubjectUris.join(', ')})`);
+  }
+
+  await updateSudo(commonWhereStatement(`
+    INSERT {
+      GRAPH ?organizationG {
+        ?s ?pNew ?oNew.
+      }
+    }
+  `));
 };
+
+

--- a/config/bb-aalst-ldes/processPage.ts
+++ b/config/bb-aalst-ldes/processPage.ts
@@ -5,7 +5,6 @@ import {
   BATCH_GRAPH,
   VERSION_PREDICATE,
   TIME_PREDICATE,
-  TARGET_GRAPH,
 } from "../environment";
 
 /**
@@ -27,7 +26,8 @@ export async function processPage() {
   logger.debug("Running custom logic to process the current page");
 
   const burgemeesterOrgaanClassificatieCodeUri = 'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4955bd72cd0e4eb895fdbfab08da0284';
-  const bekrachtigdPublicatieCodeUri = 'https://data.lblod.info/id/concept/MandatarisPublicationStatusCode/9d8fd14d-95d0-4f5e-b3a5-a56a126227b6';
+  const bekrachtigdPublicatieCodeUri = 'http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/9d8fd14d-95d0-4f5e-b3a5-a56a126227b6';
+
   await updateSudo(`
     PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
     PREFIX org: <http://www.w3.org/ns/org#>
@@ -44,12 +44,14 @@ export async function processPage() {
       ?orgaanIT org:hasPost ?mandaat .
       ?orgaanIT mandaat:isTijdspecialisatieVan ?orgaan .
       ?orgaan besluit:classificatie | org:classification ${sparqlEscapeUri(burgemeesterOrgaanClassificatieCodeUri)} .
+      ?orgaan besluit:bestuurt ?bestuurseenheid .
 
       FILTER NOT EXISTS {
         GRAPH ?organizationG {
           ?s a mandaat:Mandataris .
         }
       }
+      ?organizationG ext:ownedBy ?bestuurseenheid .
 
       GRAPH ${sparqlEscapeUri(BATCH_GRAPH)} {
         ?stream <https://w3id.org/tree#member> ?versionedMember .
@@ -61,6 +63,5 @@ export async function processPage() {
         ?versionedMember ?pNew ?oNew .
         FILTER (?pNew NOT IN ( ${sparqlEscapeUri(VERSION_PREDICATE)}, ${sparqlEscapeUri(TIME_PREDICATE)} ))
       }
-      ?organizationG ext:ownedBy ?bestuurseenheid .
     }`);
 };

--- a/config/bb-aalst-ldes/processPage.ts
+++ b/config/bb-aalst-ldes/processPage.ts
@@ -3,16 +3,29 @@ import { updateSudo } from "@lblod/mu-auth-sudo";
 import { sparqlEscapeUri } from "mu";
 import {
   BATCH_GRAPH,
-  BYPASS_MU_AUTH,
-  DIRECT_DATABASE_CONNECTION,
   VERSION_PREDICATE,
   TIME_PREDICATE,
   TARGET_GRAPH,
 } from "../environment";
 
+/**
+ * NOTE
+ * This service runs on the locally installed LMB application at the customer site.
+ *
+ * In the **normal flow**, Kalliope pushes the new "burgemeester-benoeming" (mayor) to our **central** LMB application, which then creates the mayor mandate (**mandataris**) and validates/confirms it (**bekrachtigt**).
+ *
+ * Since this is a **local** instance of our application, we cannot ask Kalliope to push the data to all locally managed instances. Therefore, we add this ldes-client service to the app.
+ *
+ * This client service will **fetch** all **validated/confirmed** ("bekrachtigde") mayor mandates from our **central** LMB LDES stream.
+ *
+ * The service focuses on mandates (**mandatarissen**) that are **not yet known** in the locally managed instance. This ensures that when a new mayor mandate is validated (**bekrachtigd**), it flows from the central LMB to the locally managed instance **only once**.
+ *
+ * If this mandate is later changed in the local instance and flows back to central LMB, we don't need to worry about it flowing right back. Since the local instance now **knows** the mandate, it will not be added or updated again by this service.
+ */
 const GEMEENTE_BESTUURSEENHEID_URI = process.env.GEMEENTE_BESTUURSEENHEID_URI || "http://data.lblod.info/id/bestuurseenheden/974816591f269bb7d74aa1720922651529f3d3b2a787f5c60b73e5a0384950a4"; // Gemeente Aalst
-
 export async function processPage() {
+  logger.debug("Running custom logic to process the current page");
+
   const burgemeesterOrgaanClassificatieCodeUri = 'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4955bd72cd0e4eb895fdbfab08da0284';
   const bekrachtigdPublicatieCodeUri = 'https://data.lblod.info/id/concept/MandatarisPublicationStatusCode/9d8fd14d-95d0-4f5e-b3a5-a56a126227b6';
   await updateSudo(`

--- a/config/bb-aalst-ldes/processPage.ts
+++ b/config/bb-aalst-ldes/processPage.ts
@@ -34,13 +34,8 @@ export async function processPage() {
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
     PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
-    DELETE {
-      GRAPH ${sparqlEscapeUri(TARGET_GRAPH)} {
-        ?s ?pOld ?oOld.
-      }
-    }
     INSERT {
-      GRAPH ${sparqlEscapeUri(TARGET_GRAPH)} {
+      GRAPH ?organizationG {
         ?s ?pNew ?oNew.
       }
     } WHERE {
@@ -54,7 +49,6 @@ export async function processPage() {
         GRAPH ?organizationG {
           ?s a mandaat:Mandataris .
         }
-        ?organizationG ext:ownedBy ?bestuurseenheid .
       }
 
       GRAPH ${sparqlEscapeUri(BATCH_GRAPH)} {
@@ -67,10 +61,6 @@ export async function processPage() {
         ?versionedMember ?pNew ?oNew .
         FILTER (?pNew NOT IN ( ${sparqlEscapeUri(VERSION_PREDICATE)}, ${sparqlEscapeUri(TIME_PREDICATE)} ))
       }
-      OPTIONAL {
-        GRAPH ${sparqlEscapeUri(TARGET_GRAPH)} {
-          ?s ?pOld ?oOld.
-        }
-      }
+      ?organizationG ext:ownedBy ?bestuurseenheid .
     }`);
 };

--- a/config/bb-aalst-ldes/processPage.ts
+++ b/config/bb-aalst-ldes/processPage.ts
@@ -1,0 +1,63 @@
+import { logger } from "../logger";
+import { updateSudo } from "@lblod/mu-auth-sudo";
+import { sparqlEscapeUri } from "mu";
+import {
+  BATCH_GRAPH,
+  BYPASS_MU_AUTH,
+  DIRECT_DATABASE_CONNECTION,
+  VERSION_PREDICATE,
+  TIME_PREDICATE,
+  TARGET_GRAPH,
+} from "../environment";
+
+const GEMEENTE_BESTUURSEENHEID_URI = process.env.GEMEENTE_BESTUURSEENHEID_URI || "http://data.lblod.info/id/bestuurseenheden/974816591f269bb7d74aa1720922651529f3d3b2a787f5c60b73e5a0384950a4"; // Gemeente Aalst
+
+export async function processPage() {
+  const burgemeesterOrgaanClassificatieCodeUri = 'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4955bd72cd0e4eb895fdbfab08da0284';
+  const bekrachtigdPublicatieCodeUri = 'https://data.lblod.info/id/concept/MandatarisPublicationStatusCode/9d8fd14d-95d0-4f5e-b3a5-a56a126227b6';
+  await updateSudo(`
+    PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+    PREFIX org: <http://www.w3.org/ns/org#>
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+    PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
+    DELETE {
+      GRAPH ${sparqlEscapeUri(TARGET_GRAPH)} {
+        ?s ?pOld ?oOld.
+      }
+    }
+    INSERT {
+      GRAPH ${sparqlEscapeUri(TARGET_GRAPH)} {
+        ?s ?pNew ?oNew.
+      }
+    } WHERE {
+      VALUES ?bestuurseenheid { ${sparqlEscapeUri(GEMEENTE_BESTUURSEENHEID_URI)} }
+      
+      ?orgaanIT org:hasPost ?mandaat .
+      ?orgaanIT mandaat:isTijdspecialisatieVan ?orgaan .
+      ?orgaan besluit:classificatie | org:classification ${sparqlEscapeUri(burgemeesterOrgaanClassificatieCodeUri)} .
+
+      FILTER NOT EXISTS {
+        GRAPH ?organizationG {
+          ?s a mandaat:Mandataris .
+        }
+        ?organizationG ext:ownedBy ?bestuurseenheid .
+      }
+
+      GRAPH ${sparqlEscapeUri(BATCH_GRAPH)} {
+        ?stream <https://w3id.org/tree#member> ?versionedMember .
+        ?versionedMember ${sparqlEscapeUri(VERSION_PREDICATE)} ?s .
+        ?versionedMember a mandaat:Mandataris .
+        ?versionedMember lmb:hasPublicationStatus ${sparqlEscapeUri(bekrachtigdPublicatieCodeUri)} .
+        ?versionedMember org:holds ?mandaat .
+        ?versionedMember ext:owningBestuurseenheid | ext:relatedTo ?bestuurseenheid .
+        ?versionedMember ?pNew ?oNew .
+        FILTER (?pNew NOT IN ( ${sparqlEscapeUri(VERSION_PREDICATE)}, ${sparqlEscapeUri(TIME_PREDICATE)} ))
+      }
+      OPTIONAL {
+        GRAPH ${sparqlEscapeUri(TARGET_GRAPH)} {
+          ?s ?pOld ?oOld.
+        }
+      }
+    }`);
+};

--- a/config/locally-managed-ldes/config.ts
+++ b/config/locally-managed-ldes/config.ts
@@ -2,8 +2,8 @@ export default {
   endpoints: [
     {
       name: "Public Stream",
-      LDES_BASE: "http://ldes-backend/public/", // note: in real life this would be an external endpoint, probably with a longer path like streams/ldes/public, same for the first page
-      FIRST_PAGE: "http://ldes-backend/public/1",
+      LDES_BASE: "https://mandatenbeheer.lblod.info/streams/ldes/public/", // note: in real life this would be an external endpoint, probably with a longer path like streams/ldes/public, same for the first page
+      FIRST_PAGE: "https://mandatenbeheer.lblod.info/streams/ldes/public/1",
       TARGET_GRAPH: "http://mu.semte.ch/graphs/public",
       STATUS_GRAPH: "http://mu.semte.ch/graphs/locally-managed/status",
       EXTRA_HEADERS: {},

--- a/config/locally-managed-ldes/environment.ts
+++ b/config/locally-managed-ldes/environment.ts
@@ -1,0 +1,121 @@
+import { v4 as uuid } from 'uuid';
+import config from './config';
+
+export const RANDOMIZE_GRAPHS =
+  (process.env.RANDOMIZE_GRAPHS || 'false') === 'true';
+export const CRON_PATTERN = process.env.CRON_PATTERN || '*/5 * * * * *';
+export const LDES_BASE = process.env.LDES_BASE;
+export const FIRST_PAGE =
+  process.env.FIRST_PAGE ||
+  'https://dev.mandatenbeheer.lblod.info/streams/ldes/public/1';
+export const WORKING_GRAPH =
+  (process.env.WORKING_GRAPH || 'http://mu.semte.ch/graphs/temp') +
+  (RANDOMIZE_GRAPHS ? `/${uuid()}` : '');
+export const BATCH_GRAPH =
+  (process.env.BATCH_GRAPH || 'http://mu.semte.ch/graphs/batch') +
+  (RANDOMIZE_GRAPHS ? `/${uuid()}` : '');
+export const BATCH_SIZE = process.env.BATCH_SIZE || 1000;
+export const STATUS_GRAPH =
+  process.env.STATUS_GRAPH || 'http://mu.semte.ch/graphs/status';
+export const TARGET_GRAPH =
+  process.env.TARGET_GRAPH || 'http://mu.semte.ch/graphs/public';
+export const DIRECT_DATABASE_CONNECTION =
+  process.env.DIRECT_DATABASE_CONNECTION || 'http://virtuoso:8890/sparql';
+export const GRAPH_STORE_URL =
+  process.env.GRAPH_STORE_URL || 'http://virtuoso:8890/sparql-graph-crud';
+export const VERSION_PREDICATE =
+  process.env.VERSION_PREDICATE || 'http://purl.org/dc/terms/isVersionOf';
+export const TIME_PREDICATE =
+  process.env.TIME_PREDICATE || 'http://www.w3.org/ns/prov#generatedAtTime';
+export const LOG_LEVEL = process.env.LOG_LEVEL || 'info';
+export const EXTRA_HEADERS = JSON.parse(process.env.EXTRA_HEADERS || '{}');
+export const BYPASS_MU_AUTH =
+  (process.env.BYPASS_MU_AUTH || 'false') === 'true';
+export const RUN_AT_STARTUP =
+  (process.env.RUN_AT_STARTUP || 'false') === 'true';
+
+const DEFAULT_NEXT_PAGE_RELATIONSHIP_RDF_TYPE =
+  'https://w3id.org/tree#GreaterThanOrEqualToRelation';
+export const NEXT_PAGE_RELATIONSHIP_RDF_TYPE =
+  process.env.NEXT_PAGE_RELATIONSHIP_RDF_TYPE ||
+  DEFAULT_NEXT_PAGE_RELATIONSHIP_RDF_TYPE;
+
+let currentStream = 0;
+
+export const environment = {
+  CRON_PATTERN,
+  WORKING_GRAPH,
+  BATCH_GRAPH,
+  BATCH_SIZE,
+  DIRECT_DATABASE_CONNECTION,
+  GRAPH_STORE_URL,
+  LOG_LEVEL,
+  BYPASS_MU_AUTH,
+  RANDOMIZE_GRAPHS,
+  // getters for the other properties so we can loop over multiple streams defined in the config
+  // if LDES_BASE is set, use the environment variables and don't look at the config file, if it isn't set, use the config file
+  getLdesBase() {
+    if (LDES_BASE) {
+      return LDES_BASE;
+    }
+    return config.endpoints[currentStream].LDES_BASE;
+  },
+  getFirstPage() {
+    if (LDES_BASE) {
+      return FIRST_PAGE;
+    }
+    return config.endpoints[currentStream].FIRST_PAGE;
+  },
+  getTargetGraph() {
+    if (LDES_BASE) {
+      return TARGET_GRAPH;
+    }
+    return config.endpoints[currentStream].TARGET_GRAPH;
+  },
+  getStatusGraph() {
+    if (LDES_BASE) {
+      return STATUS_GRAPH;
+    }
+    return config.endpoints[currentStream].STATUS_GRAPH;
+  },
+  getExtraHeaders() {
+    if (LDES_BASE) {
+      return EXTRA_HEADERS;
+    }
+    return config.endpoints[currentStream].EXTRA_HEADERS;
+  },
+  getVersionPredicate() {
+    if (LDES_BASE) {
+      return VERSION_PREDICATE;
+    }
+    return config.endpoints[currentStream].VERSION_PREDICATE;
+  },
+  getTimePredicate() {
+    if (LDES_BASE) {
+      return TIME_PREDICATE;
+    }
+    return config.endpoints[currentStream].TIME_PREDICATE;
+  },
+  getNextPageRelationshipRdfType() {
+    if (LDES_BASE) {
+      return NEXT_PAGE_RELATIONSHIP_RDF_TYPE;
+    }
+    return (
+      config.endpoints[currentStream].NEXT_PAGE_RELATIONSHIP_RDF_TYPE ||
+      DEFAULT_NEXT_PAGE_RELATIONSHIP_RDF_TYPE
+    );
+  },
+  getCurrentStreamConfig() {
+    return config.endpoints[currentStream];
+  },
+  resetCurrentStream() {
+    currentStream = 0;
+  },
+  toNextStream() {
+    currentStream++;
+    if (currentStream >= config.endpoints.length) {
+      currentStream = 0;
+    }
+    return currentStream != 0;
+  },
+};

--- a/config/locally-managed-ldes/processPage.ts
+++ b/config/locally-managed-ldes/processPage.ts
@@ -6,7 +6,7 @@ import {
   BYPASS_MU_AUTH,
   DIRECT_DATABASE_CONNECTION,
   environment,
-} from "../environment";
+} from "./environment";
 
 async function replaceExistingData() {
   let connectionOptions = {};

--- a/docker-compose.aalst.yml
+++ b/docker-compose.aalst.yml
@@ -11,8 +11,6 @@ services:
       - 'logging=true'
     restart: always
     logging: *default-logging
-    ports:
-      - '80:80'
   dispatcher:
     image: semtech/mu-dispatcher:2.1.0-beta.2
     volumes:

--- a/docker-compose.aalst.yml
+++ b/docker-compose.aalst.yml
@@ -1,0 +1,334 @@
+x-logging: &default-logging
+  driver: 'json-file'
+  options:
+    max-size: '10m'
+    max-file: '3'
+
+services:
+  identifier:
+    image: semtech/mu-identifier:1.10.1
+    labels:
+      - 'logging=true'
+    restart: always
+    logging: *default-logging
+    ports:
+      - '80:80'
+  dispatcher:
+    image: semtech/mu-dispatcher:2.1.0-beta.2
+    volumes:
+      - ./config/dispatcher:/config
+    labels:
+      - 'logging=true'
+    restart: always
+    logging: *default-logging
+  deltanotifier:
+    image: semtech/mu-delta-notifier:0.3.0
+    volumes:
+      - ./config/delta:/config
+    labels:
+      - 'logging=true'
+    restart: always
+    logging: *default-logging
+  database:
+    image: semtech/sparql-parser:0.0.14
+    environment:
+      MU_SPARQL_ENDPOINT: 'http://virtuoso:8890/sparql'
+      DATABASE_OVERLOAD_RECOVERY: 'true'
+      DATABASE_COMPATIBILITY: 'Virtuoso'
+      LISP_DYNAMIC_SPACE_SIZE: 4096
+      # Note: not sure wether it gets picked up properly, it is meant for healing-process which may make
+      # heavy queries
+      QUERY_MAX_PROCESSING_TIME: 605000
+      QUERY_MAX_EXECUTION_TIME: 605000
+    volumes:
+      - ./config/cl-authorization:/config
+      - ./data/mu-auth:/data
+    labels:
+      - 'logging=true'
+    restart: always
+    logging: *default-logging
+  virtuoso:
+    image: redpencil/virtuoso:1.3.1
+    environment:
+      SPARQL_UPDATE: 'true'
+      DEFAULT_GRAPH: 'http://mu.semte.ch/application'
+    volumes:
+      - ./data/db:/data
+      - ./config/virtuoso/virtuoso.ini:/data/virtuoso.ini # Note: on production override this setting
+      - ./config/virtuoso/:/opt/virtuoso-scripts
+    labels:
+      - 'logging=true'
+    restart: always
+    logging: *default-logging
+  migrations:
+    image: semtech/mu-migrations-service:0.6.0
+    links:
+      - virtuoso:database
+    environment:
+      MU_SPARQL_TIMEOUT: '300'
+    volumes:
+      - ./config/migrations:/data/migrations
+    labels:
+      - 'logging=true'
+    restart: always
+    logging: *default-logging
+  cache:
+    image: semtech/mu-cache:2.0.1
+    links:
+      - resource:backend
+    labels:
+      - 'logging=true'
+    restart: always
+    logging: *default-logging
+  resource:
+    image: semtech/mu-cl-resources:feature-more-backtrace
+    environment:
+      CACHE_CLEAR_PATH: 'http://cache/.mu/clear-keys'
+    volumes:
+      - ./config/resources:/config
+    labels:
+      - 'logging=true'
+    restart: always
+    logging: *default-logging
+  login:
+    image: lblod/acmidm-login-service:0.12.0
+    environment:
+      MU_APPLICATION_AUTH_DISCOVERY_URL: 'https://authenticatie-ti.vlaanderen.be/op'
+      MU_APPLICATION_AUTH_CLIENT_ID: 'a2c0d6ea-01b4-4f68-920b-10834a943c27'
+      LOG_SINK_URL: 'http://sink'
+      MU_APPLICATION_AUTH_JWK_PRIVATE_KEY: /config/jwk_private_key.json
+      MU_APPLICATION_AUTH_USERID_CLAIM: vo_id
+      MU_APPLICATION_AUTH_REDIRECT_URI: 'https://mandatenbeheer.lblod.info/authorization/callback'
+    volumes:
+      - ./config/login:/config
+    labels:
+      - 'logging=true'
+    restart: always
+    logging: *default-logging
+  file:
+    image: semtech/mu-file-service:3.4.0
+    volumes:
+      - ./data/files:/share
+    labels:
+      - 'logging=true'
+    restart: always
+    logging: *default-logging
+  frontend:
+    image: lblod/frontend-lokaal-mandatenbeheer:feature-local-deployment-aalst
+    labels:
+      - 'logging=true'
+    restart: always
+    logging: *default-logging
+    environment:
+      EMBER_ENVIRONMENT_NAME: 'QA'
+      EMBER_AUTHENTICATION_ENABLED: 'false'
+  mocklogin:
+    image: lblod/mock-login-service:0.5.0
+  sink:
+    image: nginx:1.15.2
+    volumes:
+      - ./config/sink/sink.conf:/etc/nginx/conf.d/default.conf
+    labels:
+      - 'logging=true'
+    restart: always
+    logging: *default-logging
+  form-content:
+    image: lblod/form-content-service:0.1.0
+    restart: always
+    labels:
+      - 'logging=true'
+    logging: *default-logging
+    volumes:
+      - ./config/form-content:/config
+  mandataris:
+    image: lblod/mandataris-service:0.9.12
+    labels:
+      - 'logging=true'
+    restart: always
+    logging: *default-logging
+    volumes:
+      - ./data/files/burgemeester-benoemingen:/uploads
+    environment:
+      LINKING_MANDATEES_CRON_PATTERN: '37 * * * *' # Every hour at 37th minute
+      SEND_EMAIL_FOR_MANDATARIS_WITHOUT_DECISION: false
+      BESLUIT_STAGING_GRAPH: http://mu.semte.ch/graphs/besluiten-consumed # must be the same as decision-ldes-client working graph
+  concept-scheme:
+    image: lblod/concept-scheme-service:0.0.2
+    labels:
+      - 'logging=true'
+    restart: always
+  adressenregister:
+    image: lblod/adressenregister-fuzzy-search-service:0.8.0
+    labels:
+      - 'logging=true'
+    restart: always
+    logging: *default-logging
+  merge-person-cron:
+    image: lblod/merge-person-service:1.0.0
+    labels:
+      - 'logging=true'
+    restart: always
+    depends_on:
+      - virtuoso
+  modified:
+    image: lblod/track-modified-service:0.2.0
+    environment:
+      CLEANUP_DUPLICATES_CRON: 16 * * * *
+    labels:
+      - 'logging=true'
+    volumes:
+      - ./config/modified:/config
+    restart: always
+    logging: *default-logging
+
+  authorization-wrapper:
+    image: lblod/ldes-authorization-wrapper:0.0.2
+    labels:
+      - 'logging=true'
+    restart: always
+    logging: *default-logging
+    volumes:
+      - ./config/authorization-wrapper:/config
+  ################################################################################
+  # REPORTING
+  ################################################################################
+  report-generation:
+    image: lblod/loket-report-generation-service:0.8.3
+    environment:
+      DEFAULT_GRAPH: 'http://mu.semte.ch/graphs/reports'
+      ONLY_KEEP_LATEST_REPORT: 'true'
+    volumes:
+      - ./data/files:/share
+      - ./config/reports:/config
+    restart: always
+    labels:
+      - 'logging=true'
+    logging: *default-logging
+  ##############################################################################
+  # LDES
+  ##############################################################################
+  ldes-delta-pusher:
+    image: redpencil/ldes-delta-pusher:1.2.14
+    environment:
+      LDES_ENDPOINT: 'http://ldes-backend'
+      LDES_BASE: 'https://dev.mandatenbeheer.lblod.info/streams/ldes'
+      LDES_FOLDER: public # ignored as we have an ldes config that sets the stream folder
+      DATA_FOLDER: /data
+      CRON_HEALING: '0 0 0 * * *' # Every day at midnight
+      AUTO_HEALING: 'true'
+      CRON_CHECKPOINT: '0 0 5 1 * *'
+      SUDO_QUERY_RETRY_TIMEOUT_INCREMENT_FACTOR: 0.003
+      SUDO_QUERY_RETRY_FOR_HTTP_STATUS_CODES: 429,500,502,503,504
+      MAX_PAGE_SIZE_BYTES: 10000000
+      INITIAL_STATE_LIMIT: 10000
+      # for catching up after restart
+      #LDES_STATUS_GRAPH: "http://mu.semte.ch/graphs/ldes-status"
+      DIRECT_DB_ENDPOINT: 'http://virtuoso:8890/sparql'
+      WRITE_INITIAL_STATE: 'false'
+    volumes:
+      - ./config/ldes-delta-pusher/:/config/
+      - ./data/ldes-feed/:/data/
+    restart: always
+    logging: *default-logging
+    labels:
+      - 'logging=true'
+    links:
+      - virtuoso:database
+  ldes-backend:
+    image: redpencil/fragmentation-producer:0.4.2
+    restart: always
+    logging: *default-logging
+    labels:
+      - 'logging=true'
+    environment:
+      BASE_URL: 'https://dev.mandatenbeheer.lblod.info/streams/ldes/'
+      FOLDER_DEPTH: 1
+      PAGE_RESOURCES_COUNT: 20
+      LDES_STREAM_PREFIX: 'https://dev.mandatenbeheer.lblod.info/streams/ldes/'
+      TIME_TREE_RELATION_PATH: 'http://www.w3.org/ns/prov#generatedAtTime'
+      CACHE_SIZE: 10
+      DATA_FOLDER: '/data'
+      ENABLE_AUTH: 'false'
+    volumes:
+      - './data/ldes-feed/:/data/'
+  sparql-authorization-wrapper:
+    image: lblod/sparql-authorization-wrapper-service:1.0.0
+    volumes:
+      - ./config/sparql-authorization-wrapper:/config
+    restart: always
+    labels:
+      - 'logging=true'
+    logging: *default-logging
+  project-scripts:
+    image: semtech/simple-script-store:1.0.0
+    volumes:
+      - ./scripts/:/app/scripts/
+    restart: 'no'
+  op-public-consumer:
+    image: lblod/delta-consumer:0.1.4
+    environment:
+      DCR_SERVICE_NAME: 'op-public-consumer'
+      DCR_SYNC_FILES_PATH: '/sync/public/files'
+      DCR_SYNC_DATASET_SUBJECT:
+        "http://data.lblod.info/datasets/delta-producer/dumps\
+        /PublicCacheGraphDump"
+      DCR_INITIAL_SYNC_JOB_OPERATION:
+        "http://redpencil.data.gift/id/jobs/concept/Job\
+        Operation/deltas/consumer/initialSync/op-public"
+      DCR_DELTA_SYNC_JOB_OPERATION:
+        "http://redpencil.data.gift/id/jobs/concept/JobOp\
+        eration/deltas/consumer/deltaSync/op-public"
+      DCR_JOB_CREATOR_URI: 'http://data.lblod.info/services/id/op-public-consumer'
+      DCR_DISABLE_INITIAL_SYNC: 'false'
+      DCR_WAIT_FOR_INITIAL_SYNC: 'true'
+      DCR_KEEP_DELTA_FILES: 'true'
+      DCR_START_FROM_DELTA_TIMESTAMP: '2025-01-01T00:00:00Z'
+      DCR_DELTA_JOBS_RETENTION_PERIOD: '30'
+      DCR_ENABLE_TRIPLE_REMAPPING: 'true'
+      DCR_LANDING_ZONE_GRAPH: 'http://mu.semte.ch/graphs/landing-zone/op-public'
+      DCR_REMAPPING_GRAPH: 'http://mu.semte.ch/graphs/public'
+      DCR_BATCH_SIZE: 1000
+      SUDO_QUERY_RETRY_FOR_HTTP_STATUS_CODES: '404,500,503'
+      SUDO_QUERY_RETRY: 'true'
+      DCR_SYNC_BASE_URL: 'https://organisaties.abb.vlaanderen.be'
+      DCR_DISABLE_DELTA_INGEST: 'false'
+    volumes:
+      - ./config/op-consumer/mapping:/config/mapping
+      - ./data/files/consumer-files/op-public:/consumer-files/
+    restart: always
+    labels:
+      - 'logging=true'
+    logging: *default-logging
+  locally-managed-ldes-client:
+    image: lblod/ldes-client:0.1.0
+    restart: always
+    profiles:
+      - 'disabled'
+    environment:
+      WORKING_GRAPH: http://mu.semte.ch/graphs/locally-managed-tmp
+      DIRECT_DATABASE_CONNECTION: 'http://virtuoso:8890/sparql'
+      RANDOMIZE_GRAPHS: true
+      BATCH_SIZE: 100
+      BYPASS_MU_AUTH: false
+    volumes:
+      - ./config/locally-managed-ldes:/config
+    labels:
+      - 'logging=true'
+    logging: *default-logging
+  bb-aalst-ldes-client:
+    image: lblod/ldes-client:0.0.3
+    volumes:
+      - ./config/bb-aalst-ldes:/config
+    restart: always
+    environment:
+      CRON_PATTERN: '3 * * * *' # Every hour at minute 3
+      LDES_BASE: https://mandatenbeheer.lblod.info/streams/ldes/public/
+      FIRST_PAGE: https://mandatenbeheer.lblod.info/streams/ldes/public/1
+      TARGET_GRAPH: http://mu.semte.ch/graphs/aalst-bb-lmb-consumed
+      WORKING_GRAPH: http://mu.semte.ch/graphs/aalst-bb-lmb-consumed-tmp
+      DIRECT_DATABASE_CONNECTION: 'http://virtuoso:8890/sparql'
+      RANDOMIZE_GRAPHS: true
+      BATCH_SIZE: 100
+    labels:
+      - 'logging=true'
+    logging: *default-logging

--- a/docker-compose.aalst.yml
+++ b/docker-compose.aalst.yml
@@ -1,36 +1,40 @@
 services:
   identifier:
     ports:
-      - "81:80"
+      - '81:80'
   virtuoso:
     volumes:
       - ./config/virtuoso/virtuoso.ini:/data/virtuoso-production.ini
   login:
-    profiles:
-        - disabled
+    # profiles:
+    #     - disabled
     environment:
-      MU_APPLICATION_AUTH_DISCOVERY_URL: "https://authenticatie-ti.vlaanderen.be/op"
-      MU_APPLICATION_AUTH_CLIENT_ID: "a2c0d6ea-01b4-4f68-920b-10834a943c27"
+      MU_APPLICATION_AUTH_DISCOVERY_URL: 'https://authenticatie-ti.vlaanderen.be/op'
+      MU_APPLICATION_AUTH_CLIENT_ID: 'a2c0d6ea-01b4-4f68-920b-10834a943c27'
       MU_APPLICATION_AUTH_JWK_PRIVATE_KEY: /config/jwk_private_key.json
-      MU_APPLICATION_AUTH_REDIRECT_URI: "https://mandatenbeheer.lblod.info/authorization/callback"
+      MU_APPLICATION_AUTH_REDIRECT_URI: 'https://mandatenbeheer.lblod.info/authorization/callback'
   impersonation:
     profiles:
       - disabled
   frontend:
+    image: lblod/frontend-lokaal-mandatenbeheer:feature-local-deployment-aalst
     environment:
-      EMBER_ENVIRONMENT_NAME: "PROD"
-      EMBER_AUTHENTICATION_ENABLED: "false"
+      EMBER_ENVIRONMENT_NAME: 'PROD'
+      EMBER_AUTHENTICATION_ENABLED: 'false'
   mandataris:
     environment:
-      EMAIL_FROM_MANDATARIS_WITHOUT_DECISION: "lokaalmandatenbeheer@abb.vlaanderen.be" # Must be the same as EMAIL_ADDRESS in deliver-email service
+      EMAIL_FROM_MANDATARIS_WITHOUT_DECISION: 'lokaalmandatenbeheer@abb.vlaanderen.be' # Must be the same as EMAIL_ADDRESS in deliver-email service
       SEND_EMAIL_FOR_MANDATARIS_WITHOUT_DECISION: false
   ldes-delta-pusher:
     environment:
       # LDES_BASE: "https://dev.mandatenbeheer.lblod.info/streams/ldes"
-      WRITE_INITIAL_STATE: "false"
+      LDES_STREAM_PREFIX: 'http://localhost/streams/ldes/'
+      LDES_BASE: 'http://localhost/streams/ldes/'
+      WRITE_INITIAL_STATE: 'false'
   ldes-backend:
     environment:
-      BASE_URL: "http://ldes-backend/"
+      LDES_STREAM_PREFIX: "http://localhost/streams/ldes/"
+      BASE_URL: 'http://ldes-backend/'
       #BASE_URL: "https://dev.mandatenbeheer.lblod.info/streams/ldes/"
       # LDES_STREAM_PREFIX: "https://dev.mandatenbeheer.lblod.info/streams/ldes/"
   decision-ldes-client:
@@ -44,25 +48,25 @@ services:
     profiles:
       - disabled
     environment:
-      EMAIL_PROTOCOL: "smtp"
-      EMAIL_ADDRESS: "lokaalmandatenbeheer@abb.vlaanderen.be"
-      EMAIL_PASSWORD: "myemailpassword"
+      EMAIL_PROTOCOL: 'smtp'
+      EMAIL_ADDRESS: 'lokaalmandatenbeheer@abb.vlaanderen.be'
+      EMAIL_PASSWORD: 'myemailpassword'
       FROM_NAME: "Lokaal Mandatenbeheer"
-      WELL_KNOWN_SERVICE: "Outlook365"
-      NODE_ENV: "production"
+      WELL_KNOWN_SERVICE: 'Outlook365'
+      NODE_ENV: 'production'
   vendor-management-consumer:
     profiles:
       - disabled
     environment:
-      DCR_SERVICE_NAME: "vendor-management-consumer"
-      DCR_SYNC_BASE_URL: "https://dev.loket.lblod.info/"
-      DCR_SYNC_LOGIN_ENDPOINT: "https://dev.loket.lblod.info/sync/vendor-management/login" # Add DCR_SECRET_KEY in docker-compose.override.yml
+      DCR_SERVICE_NAME: 'vendor-management-consumer'
+      DCR_SYNC_BASE_URL: 'https://dev.loket.lblod.info/'
+      DCR_SYNC_LOGIN_ENDPOINT: 'https://dev.loket.lblod.info/sync/vendor-management/login' # Add DCR_SECRET_KEY in docker-compose.override.yml
   op-public-consumer:
     environment:
-      DCR_DISABLE_INITIAL_SYNC: "false"
-      DCR_WAIT_FOR_INITIAL_SYNC: "true"
-      DCR_KEEP_DELTA_FILES: "true"
-      DCR_START_FROM_DELTA_TIMESTAMP: "2025-01-01T00:00:00Z"
+      DCR_DISABLE_INITIAL_SYNC: 'true'
+      DCR_WAIT_FOR_INITIAL_SYNC: 'false'
+      DCR_KEEP_DELTA_FILES: 'true'
+      DCR_START_FROM_DELTA_TIMESTAMP: '2025-01-01T00:00:00Z'
   bb-aalst-ldes-client:
     environment:
       LDES_BASE: https://mandatenbeheer.lblod.info/streams/ldes/public/

--- a/docker-compose.aalst.yml
+++ b/docker-compose.aalst.yml
@@ -1,332 +1,69 @@
-x-logging: &default-logging
-  driver: 'json-file'
-  options:
-    max-size: '10m'
-    max-file: '3'
-
 services:
   identifier:
-    image: semtech/mu-identifier:1.10.1
-    labels:
-      - 'logging=true'
-    restart: always
-    logging: *default-logging
-  dispatcher:
-    image: semtech/mu-dispatcher:2.1.0-beta.2
-    volumes:
-      - ./config/dispatcher:/config
-    labels:
-      - 'logging=true'
-    restart: always
-    logging: *default-logging
-  deltanotifier:
-    image: semtech/mu-delta-notifier:0.3.0
-    volumes:
-      - ./config/delta:/config
-    labels:
-      - 'logging=true'
-    restart: always
-    logging: *default-logging
-  database:
-    image: semtech/sparql-parser:0.0.14
-    environment:
-      MU_SPARQL_ENDPOINT: 'http://virtuoso:8890/sparql'
-      DATABASE_OVERLOAD_RECOVERY: 'true'
-      DATABASE_COMPATIBILITY: 'Virtuoso'
-      LISP_DYNAMIC_SPACE_SIZE: 4096
-      # Note: not sure wether it gets picked up properly, it is meant for healing-process which may make
-      # heavy queries
-      QUERY_MAX_PROCESSING_TIME: 605000
-      QUERY_MAX_EXECUTION_TIME: 605000
-    volumes:
-      - ./config/cl-authorization:/config
-      - ./data/mu-auth:/data
-    labels:
-      - 'logging=true'
-    restart: always
-    logging: *default-logging
+    ports:
+      - "81:80"
   virtuoso:
-    image: redpencil/virtuoso:1.3.1
-    environment:
-      SPARQL_UPDATE: 'true'
-      DEFAULT_GRAPH: 'http://mu.semte.ch/application'
     volumes:
-      - ./data/db:/data
-      - ./config/virtuoso/virtuoso.ini:/data/virtuoso.ini # Note: on production override this setting
-      - ./config/virtuoso/:/opt/virtuoso-scripts
-    labels:
-      - 'logging=true'
-    restart: always
-    logging: *default-logging
-  migrations:
-    image: semtech/mu-migrations-service:0.6.0
-    links:
-      - virtuoso:database
-    environment:
-      MU_SPARQL_TIMEOUT: '300'
-    volumes:
-      - ./config/migrations:/data/migrations
-    labels:
-      - 'logging=true'
-    restart: always
-    logging: *default-logging
-  cache:
-    image: semtech/mu-cache:2.0.1
-    links:
-      - resource:backend
-    labels:
-      - 'logging=true'
-    restart: always
-    logging: *default-logging
-  resource:
-    image: semtech/mu-cl-resources:feature-more-backtrace
-    environment:
-      CACHE_CLEAR_PATH: 'http://cache/.mu/clear-keys'
-    volumes:
-      - ./config/resources:/config
-    labels:
-      - 'logging=true'
-    restart: always
-    logging: *default-logging
+      - ./config/virtuoso/virtuoso.ini:/data/virtuoso-production.ini
   login:
-    image: lblod/acmidm-login-service:0.12.0
-    environment:
-      MU_APPLICATION_AUTH_DISCOVERY_URL: 'https://authenticatie-ti.vlaanderen.be/op'
-      MU_APPLICATION_AUTH_CLIENT_ID: 'a2c0d6ea-01b4-4f68-920b-10834a943c27'
-      LOG_SINK_URL: 'http://sink'
-      MU_APPLICATION_AUTH_JWK_PRIVATE_KEY: /config/jwk_private_key.json
-      MU_APPLICATION_AUTH_USERID_CLAIM: vo_id
-      MU_APPLICATION_AUTH_REDIRECT_URI: 'https://mandatenbeheer.lblod.info/authorization/callback'
-    volumes:
-      - ./config/login:/config
-    labels:
-      - 'logging=true'
-    restart: always
-    logging: *default-logging
-  file:
-    image: semtech/mu-file-service:3.4.0
-    volumes:
-      - ./data/files:/share
-    labels:
-      - 'logging=true'
-    restart: always
-    logging: *default-logging
-  frontend:
-    image: lblod/frontend-lokaal-mandatenbeheer:feature-local-deployment-aalst
-    labels:
-      - 'logging=true'
-    restart: always
-    logging: *default-logging
-    environment:
-      EMBER_ENVIRONMENT_NAME: 'QA'
-      EMBER_AUTHENTICATION_ENABLED: 'false'
-  mocklogin:
-    image: lblod/mock-login-service:0.5.0
-  sink:
-    image: nginx:1.15.2
-    volumes:
-      - ./config/sink/sink.conf:/etc/nginx/conf.d/default.conf
-    labels:
-      - 'logging=true'
-    restart: always
-    logging: *default-logging
-  form-content:
-    image: lblod/form-content-service:0.1.0
-    restart: always
-    labels:
-      - 'logging=true'
-    logging: *default-logging
-    volumes:
-      - ./config/form-content:/config
-  mandataris:
-    image: lblod/mandataris-service:0.9.12
-    labels:
-      - 'logging=true'
-    restart: always
-    logging: *default-logging
-    volumes:
-      - ./data/files/burgemeester-benoemingen:/uploads
-    environment:
-      LINKING_MANDATEES_CRON_PATTERN: '37 * * * *' # Every hour at 37th minute
-      SEND_EMAIL_FOR_MANDATARIS_WITHOUT_DECISION: false
-      BESLUIT_STAGING_GRAPH: http://mu.semte.ch/graphs/besluiten-consumed # must be the same as decision-ldes-client working graph
-  concept-scheme:
-    image: lblod/concept-scheme-service:0.0.2
-    labels:
-      - 'logging=true'
-    restart: always
-  adressenregister:
-    image: lblod/adressenregister-fuzzy-search-service:0.8.0
-    labels:
-      - 'logging=true'
-    restart: always
-    logging: *default-logging
-  merge-person-cron:
-    image: lblod/merge-person-service:1.0.0
-    labels:
-      - 'logging=true'
-    restart: always
-    depends_on:
-      - virtuoso
-  modified:
-    image: lblod/track-modified-service:0.2.0
-    environment:
-      CLEANUP_DUPLICATES_CRON: 16 * * * *
-    labels:
-      - 'logging=true'
-    volumes:
-      - ./config/modified:/config
-    restart: always
-    logging: *default-logging
-
-  authorization-wrapper:
-    image: lblod/ldes-authorization-wrapper:0.0.2
-    labels:
-      - 'logging=true'
-    restart: always
-    logging: *default-logging
-    volumes:
-      - ./config/authorization-wrapper:/config
-  ################################################################################
-  # REPORTING
-  ################################################################################
-  report-generation:
-    image: lblod/loket-report-generation-service:0.8.3
-    environment:
-      DEFAULT_GRAPH: 'http://mu.semte.ch/graphs/reports'
-      ONLY_KEEP_LATEST_REPORT: 'true'
-    volumes:
-      - ./data/files:/share
-      - ./config/reports:/config
-    restart: always
-    labels:
-      - 'logging=true'
-    logging: *default-logging
-  ##############################################################################
-  # LDES
-  ##############################################################################
-  ldes-delta-pusher:
-    image: redpencil/ldes-delta-pusher:1.2.14
-    environment:
-      LDES_ENDPOINT: 'http://ldes-backend'
-      LDES_BASE: 'https://dev.mandatenbeheer.lblod.info/streams/ldes'
-      LDES_FOLDER: public # ignored as we have an ldes config that sets the stream folder
-      DATA_FOLDER: /data
-      CRON_HEALING: '0 0 0 * * *' # Every day at midnight
-      AUTO_HEALING: 'true'
-      CRON_CHECKPOINT: '0 0 5 1 * *'
-      SUDO_QUERY_RETRY_TIMEOUT_INCREMENT_FACTOR: 0.003
-      SUDO_QUERY_RETRY_FOR_HTTP_STATUS_CODES: 429,500,502,503,504
-      MAX_PAGE_SIZE_BYTES: 10000000
-      INITIAL_STATE_LIMIT: 10000
-      # for catching up after restart
-      #LDES_STATUS_GRAPH: "http://mu.semte.ch/graphs/ldes-status"
-      DIRECT_DB_ENDPOINT: 'http://virtuoso:8890/sparql'
-      WRITE_INITIAL_STATE: 'false'
-    volumes:
-      - ./config/ldes-delta-pusher/:/config/
-      - ./data/ldes-feed/:/data/
-    restart: always
-    logging: *default-logging
-    labels:
-      - 'logging=true'
-    links:
-      - virtuoso:database
-  ldes-backend:
-    image: redpencil/fragmentation-producer:0.4.2
-    restart: always
-    logging: *default-logging
-    labels:
-      - 'logging=true'
-    environment:
-      BASE_URL: 'https://dev.mandatenbeheer.lblod.info/streams/ldes/'
-      FOLDER_DEPTH: 1
-      PAGE_RESOURCES_COUNT: 20
-      LDES_STREAM_PREFIX: 'https://dev.mandatenbeheer.lblod.info/streams/ldes/'
-      TIME_TREE_RELATION_PATH: 'http://www.w3.org/ns/prov#generatedAtTime'
-      CACHE_SIZE: 10
-      DATA_FOLDER: '/data'
-      ENABLE_AUTH: 'false'
-    volumes:
-      - './data/ldes-feed/:/data/'
-  sparql-authorization-wrapper:
-    image: lblod/sparql-authorization-wrapper-service:1.0.0
-    volumes:
-      - ./config/sparql-authorization-wrapper:/config
-    restart: always
-    labels:
-      - 'logging=true'
-    logging: *default-logging
-  project-scripts:
-    image: semtech/simple-script-store:1.0.0
-    volumes:
-      - ./scripts/:/app/scripts/
-    restart: 'no'
-  op-public-consumer:
-    image: lblod/delta-consumer:0.1.4
-    environment:
-      DCR_SERVICE_NAME: 'op-public-consumer'
-      DCR_SYNC_FILES_PATH: '/sync/public/files'
-      DCR_SYNC_DATASET_SUBJECT:
-        "http://data.lblod.info/datasets/delta-producer/dumps\
-        /PublicCacheGraphDump"
-      DCR_INITIAL_SYNC_JOB_OPERATION:
-        "http://redpencil.data.gift/id/jobs/concept/Job\
-        Operation/deltas/consumer/initialSync/op-public"
-      DCR_DELTA_SYNC_JOB_OPERATION:
-        "http://redpencil.data.gift/id/jobs/concept/JobOp\
-        eration/deltas/consumer/deltaSync/op-public"
-      DCR_JOB_CREATOR_URI: 'http://data.lblod.info/services/id/op-public-consumer'
-      DCR_DISABLE_INITIAL_SYNC: 'false'
-      DCR_WAIT_FOR_INITIAL_SYNC: 'true'
-      DCR_KEEP_DELTA_FILES: 'true'
-      DCR_START_FROM_DELTA_TIMESTAMP: '2025-01-01T00:00:00Z'
-      DCR_DELTA_JOBS_RETENTION_PERIOD: '30'
-      DCR_ENABLE_TRIPLE_REMAPPING: 'true'
-      DCR_LANDING_ZONE_GRAPH: 'http://mu.semte.ch/graphs/landing-zone/op-public'
-      DCR_REMAPPING_GRAPH: 'http://mu.semte.ch/graphs/public'
-      DCR_BATCH_SIZE: 1000
-      SUDO_QUERY_RETRY_FOR_HTTP_STATUS_CODES: '404,500,503'
-      SUDO_QUERY_RETRY: 'true'
-      DCR_SYNC_BASE_URL: 'https://organisaties.abb.vlaanderen.be'
-      DCR_DISABLE_DELTA_INGEST: 'false'
-    volumes:
-      - ./config/op-consumer/mapping:/config/mapping
-      - ./data/files/consumer-files/op-public:/consumer-files/
-    restart: always
-    labels:
-      - 'logging=true'
-    logging: *default-logging
-  locally-managed-ldes-client:
-    image: lblod/ldes-client:0.1.0
-    restart: always
     profiles:
-      - 'disabled'
+        - disabled
     environment:
-      WORKING_GRAPH: http://mu.semte.ch/graphs/locally-managed-tmp
-      DIRECT_DATABASE_CONNECTION: 'http://virtuoso:8890/sparql'
-      RANDOMIZE_GRAPHS: true
-      BATCH_SIZE: 100
-      BYPASS_MU_AUTH: false
-    volumes:
-      - ./config/locally-managed-ldes:/config
-    labels:
-      - 'logging=true'
-    logging: *default-logging
+      MU_APPLICATION_AUTH_DISCOVERY_URL: "https://authenticatie-ti.vlaanderen.be/op"
+      MU_APPLICATION_AUTH_CLIENT_ID: "a2c0d6ea-01b4-4f68-920b-10834a943c27"
+      MU_APPLICATION_AUTH_JWK_PRIVATE_KEY: /config/jwk_private_key.json
+      MU_APPLICATION_AUTH_REDIRECT_URI: "https://mandatenbeheer.lblod.info/authorization/callback"
+  impersonation:
+    profiles:
+      - disabled
+  frontend:
+    environment:
+      EMBER_ENVIRONMENT_NAME: "PROD"
+      EMBER_AUTHENTICATION_ENABLED: "false"
+  mandataris:
+    environment:
+      EMAIL_FROM_MANDATARIS_WITHOUT_DECISION: "lokaalmandatenbeheer@abb.vlaanderen.be" # Must be the same as EMAIL_ADDRESS in deliver-email service
+      SEND_EMAIL_FOR_MANDATARIS_WITHOUT_DECISION: false
+  ldes-delta-pusher:
+    environment:
+      # LDES_BASE: "https://dev.mandatenbeheer.lblod.info/streams/ldes"
+      WRITE_INITIAL_STATE: "false"
+  ldes-backend:
+    environment:
+      BASE_URL: "http://ldes-backend/"
+      #BASE_URL: "https://dev.mandatenbeheer.lblod.info/streams/ldes/"
+      # LDES_STREAM_PREFIX: "https://dev.mandatenbeheer.lblod.info/streams/ldes/"
+  decision-ldes-client:
+    environment:
+      LDES_BASE: https://mandaten-besluiten.lblod.info/streams/ldes/public/
+      FIRST_PAGE: https://mandaten-besluiten.lblod.info/streams/ldes/public/1
+  vendor-login:
+    profiles:
+      - disabled
+  deliver-email:
+    profiles:
+      - disabled
+    environment:
+      EMAIL_PROTOCOL: "smtp"
+      EMAIL_ADDRESS: "lokaalmandatenbeheer@abb.vlaanderen.be"
+      EMAIL_PASSWORD: "myemailpassword"
+      FROM_NAME: "Lokaal Mandatenbeheer"
+      WELL_KNOWN_SERVICE: "Outlook365"
+      NODE_ENV: "production"
+  vendor-management-consumer:
+    profiles:
+      - disabled
+    environment:
+      DCR_SERVICE_NAME: "vendor-management-consumer"
+      DCR_SYNC_BASE_URL: "https://dev.loket.lblod.info/"
+      DCR_SYNC_LOGIN_ENDPOINT: "https://dev.loket.lblod.info/sync/vendor-management/login" # Add DCR_SECRET_KEY in docker-compose.override.yml
+  op-public-consumer:
+    environment:
+      DCR_DISABLE_INITIAL_SYNC: "false"
+      DCR_WAIT_FOR_INITIAL_SYNC: "true"
+      DCR_KEEP_DELTA_FILES: "true"
+      DCR_START_FROM_DELTA_TIMESTAMP: "2025-01-01T00:00:00Z"
   bb-aalst-ldes-client:
-    image: lblod/ldes-client:0.0.3
-    volumes:
-      - ./config/bb-aalst-ldes:/config
-    restart: always
     environment:
-      CRON_PATTERN: '3 * * * *' # Every hour at minute 3
       LDES_BASE: https://mandatenbeheer.lblod.info/streams/ldes/public/
       FIRST_PAGE: https://mandatenbeheer.lblod.info/streams/ldes/public/1
-      TARGET_GRAPH: http://mu.semte.ch/graphs/aalst-bb-lmb-consumed
-      WORKING_GRAPH: http://mu.semte.ch/graphs/aalst-bb-lmb-consumed-tmp
-      DIRECT_DATABASE_CONNECTION: 'http://virtuoso:8890/sparql'
-      RANDOMIZE_GRAPHS: true
-      BATCH_SIZE: 100
-    labels:
-      - 'logging=true'
-    logging: *default-logging

--- a/docker-compose.aalst.yml
+++ b/docker-compose.aalst.yml
@@ -6,16 +6,13 @@ services:
     volumes:
       - ./config/virtuoso/virtuoso.ini:/data/virtuoso-production.ini
   login:
-    # profiles:
-    #     - disabled
+    profiles:
+        - disabled
     environment:
       MU_APPLICATION_AUTH_DISCOVERY_URL: 'https://authenticatie-ti.vlaanderen.be/op'
       MU_APPLICATION_AUTH_CLIENT_ID: 'a2c0d6ea-01b4-4f68-920b-10834a943c27'
       MU_APPLICATION_AUTH_JWK_PRIVATE_KEY: /config/jwk_private_key.json
       MU_APPLICATION_AUTH_REDIRECT_URI: 'https://mandatenbeheer.lblod.info/authorization/callback'
-  impersonation:
-    profiles:
-      - disabled
   frontend:
     image: lblod/frontend-lokaal-mandatenbeheer:feature-local-deployment-aalst
     environment:
@@ -25,6 +22,7 @@ services:
     environment:
       EMAIL_FROM_MANDATARIS_WITHOUT_DECISION: 'lokaalmandatenbeheer@abb.vlaanderen.be' # Must be the same as EMAIL_ADDRESS in deliver-email service
       SEND_EMAIL_FOR_MANDATARIS_WITHOUT_DECISION: false
+      NOTIFICATION_CRON_PATTERN: false
   ldes-delta-pusher:
     environment:
       # LDES_BASE: "https://dev.mandatenbeheer.lblod.info/streams/ldes"
@@ -41,26 +39,6 @@ services:
     environment:
       LDES_BASE: https://mandaten-besluiten.lblod.info/streams/ldes/public/
       FIRST_PAGE: https://mandaten-besluiten.lblod.info/streams/ldes/public/1
-  vendor-login:
-    profiles:
-      - disabled
-  deliver-email:
-    profiles:
-      - disabled
-    environment:
-      EMAIL_PROTOCOL: 'smtp'
-      EMAIL_ADDRESS: 'lokaalmandatenbeheer@abb.vlaanderen.be'
-      EMAIL_PASSWORD: 'myemailpassword'
-      FROM_NAME: "Lokaal Mandatenbeheer"
-      WELL_KNOWN_SERVICE: 'Outlook365'
-      NODE_ENV: 'production'
-  vendor-management-consumer:
-    profiles:
-      - disabled
-    environment:
-      DCR_SERVICE_NAME: 'vendor-management-consumer'
-      DCR_SYNC_BASE_URL: 'https://dev.loket.lblod.info/'
-      DCR_SYNC_LOGIN_ENDPOINT: 'https://dev.loket.lblod.info/sync/vendor-management/login' # Add DCR_SECRET_KEY in docker-compose.override.yml
   op-public-consumer:
     environment:
       DCR_DISABLE_INITIAL_SYNC: 'true'
@@ -71,3 +49,18 @@ services:
     environment:
       LDES_BASE: https://mandatenbeheer.lblod.info/streams/ldes/public/
       FIRST_PAGE: https://mandatenbeheer.lblod.info/streams/ldes/public/1
+  locally-managed-ldes-client:
+    profiles:
+      - disabled
+  impersonation:
+    profiles:
+      - disabled
+  vendor-management-consumer:
+    profiles:
+      - disabled
+  vendor-login:
+    profiles:
+      - disabled
+  deliver-email:
+    profiles:
+      - disabled

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -129,3 +129,8 @@ services:
       #DCR_CRON_PATTERN_DELTA_SYNC: '* * * * *' # this is every minute      
   locally-managed-ldes-client:
     restart: "no"
+  bb-aalst-ldes-client:
+    restart: "no"
+    environment:
+      RUN_AT_STARTUP: false
+      LOG_LEVEL: info # error, warn, info, verbose, debug, or silly. Default: info

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -381,7 +381,7 @@ services:
       - "logging=true"
     logging: *default-logging
   locally-managed-ldes-client:
-    image: lblod/ldes-client:0.0.3
+    image: lblod/ldes-client:latest
     restart: always
     environment:
       WORKING_GRAPH: http://mu.semte.ch/graphs/locally-managed-tmp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -381,7 +381,7 @@ services:
       - "logging=true"
     logging: *default-logging
   locally-managed-ldes-client:
-    image: lblod/ldes-client:latest
+    image: lblod/ldes-client:0.0.5
     restart: always
     environment:
       STATUS_GRAPH: http://mu.semte.ch/graphs/locally-managed/status

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -260,6 +260,8 @@ services:
       - "./data/ldes-feed/:/data/"
   decision-ldes-client:
     image: lblod/ldes-client:0.0.3
+    profiles:
+      - isDisabledOnLocalSetup
     links:
       - database:database
       - virtuoso:virtuoso
@@ -283,6 +285,8 @@ services:
     image: lblod/vendor-login-service:1.4.0
     environment:
       USE_HASHED_KEY: "true"
+    profiles:
+      - isDisabledOnLocalSetup
     restart: always
     labels:
       - "logging=true"
@@ -318,6 +322,8 @@ services:
     logging: *default-logging
   vendor-management-consumer:
     image: lblod/delta-consumer:0.0.26
+    profiles:
+      - isDisabledOnLocalSetup
     environment:
       DCR_SERVICE_NAME: "vendor-management-consumer"
       DCR_SYNC_BASE_URL: "https://dev.loket.lblod.info/"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -390,3 +390,20 @@ services:
     labels:
       - "logging=true"
     logging: *default-logging
+  bb-aalst-ldes-client:
+    image: lblod/ldes-client:0.0.3
+    volumes:
+    - ./config/bb-aalst-ldes:/config
+    restart: always
+    environment:
+      CRON_PATTERN: "3 * * * *" # Every hour at minute 3
+      LDES_BASE: https://mandatenbeheer.lblod.info/streams/ldes/public/
+      FIRST_PAGE: https://mandatenbeheer.lblod.info/streams/ldes/public/1
+      TARGET_GRAPH: http://mu.semte.ch/graphs/aalst-bb-lmb-consumed
+      WORKING_GRAPH: http://mu.semte.ch/graphs/aalst-bb-lmb-consumed-tmp
+      DIRECT_DATABASE_CONNECTION: 'http://virtuoso:8890/sparql'
+      RANDOMIZE_GRAPHS: true
+      BATCH_SIZE: 100
+    labels:
+      - "logging=true"
+    logging: *default-logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -384,7 +384,8 @@ services:
     image: lblod/ldes-client:latest
     restart: always
     environment:
-      WORKING_GRAPH: http://mu.semte.ch/graphs/locally-managed-tmp
+      STATUS_GRAPH: http://mu.semte.ch/graphs/locally-managed/status
+      WORKING_GRAPH: http://mu.semte.ch/graphs/locally-managed/tmp
       DIRECT_DATABASE_CONNECTION: "http://virtuoso:8890/sparql"
       VERSION_PREDICATE: "http://purl.org/dc/terms/isVersionOf"
       RANDOMIZE_GRAPHS: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -381,13 +381,12 @@ services:
       - "logging=true"
     logging: *default-logging
   locally-managed-ldes-client:
-    image: lblod/ldes-client:0.1.0
+    image: lblod/ldes-client:0.0.3
     restart: always
-    profiles:
-      - "disabled"
     environment:
       WORKING_GRAPH: http://mu.semte.ch/graphs/locally-managed-tmp
       DIRECT_DATABASE_CONNECTION: "http://virtuoso:8890/sparql"
+      VERSION_PREDICATE: "http://purl.org/dc/terms/isVersionOf"
       RANDOMIZE_GRAPHS: true
       BATCH_SIZE: 100
       BYPASS_MU_AUTH: false


### PR DESCRIPTION
## Description

1. Disabled the services that should not run in the local setup
2. Added ldes-client that will  manage the burgemeester-benoemingen from central LMB
3. /

## What to test

1. No services running that should not be
2. Burgemeester-benoeming ldes is running and starts at the last page of the stream (all are bekrachtigd now so we can start from there)
3.  Added a log when there is a burgemeester found 

## How to test | BB

- cleanup the ldes-client status graph
```org
#+begin_src sparql
drop silent graph <http://mu.semte.ch/graphs/status>
#+end_src

```
- remove current burgemeester + aangewezen
```org
#+begin_src sparql
  delete {
    graph ?g {
      ?s ?p ?o .
    }
  }
  where {
    VALUES ?id {
      "bb14b917-df59-4274-9ad4-feed115e072e" # burgemeester
      "672354C8AE5F6D098DC0080E" # aangewezen burgemeester
    }
    GRAPH ?g {
      ?s ?pp ?id .
      ?s ?p ?o .
    }
  }
#+end_src
```
- run the client 
```yml
    environment:
      LDES_BASE: https://mandatenbeheer.lblod.info/streams/ldes/public/
      TARGET_GRAPH: http://mu.semte.ch/graphs/aalst-bb-lmb-consumed
      WORKING_GRAPH: http://mu.semte.ch/graphs/aalst-bb-lmb-consumed-tmp
      DIRECT_DATABASE_CONNECTION: 'http://virtuoso:8890/sparql'
      RANDOMIZE_GRAPHS: true
      RUN_AT_STARTUP: "true"
      LOG_LEVEL: debug # error, warn, info, verbose, debug, or silly. Default: info
      BATCH_SIZE: 350
      FIRST_PAGE: "https://mandatenbeheer.lblod.info/streams/ldes/public/14200" # 14242 is the first hit on mandataris aalst burgemeester Christooph D'Haese
      NODE_ENV: development
```
- follow the pages in the logs 
```sh
drc logs -f --tail 10 | grep "currentPage"
```
OR
```
drc logs -f  bb-aalst-ldes-client | grep "Found"
```
```
bb-aalst-ldes-client-1  | {"level":"info","message":"Found 1 subjects for burgemeester-benoemingen. (http://data.lblod.info/id/mandatarissen/bb14b917-df59-4274-9ad4-feed115e072e)"}
bb-aalst-ldes-client-1  | {"level":"info","message":"Found 1 subjects for burgemeester-benoemingen. (http://data.lblod.info/id/mandatarissen/672354C8AE5F6D098DC0080E)"}
```

- check if the two mandatarissen are added (frontend / query)
```org
** Mandataris already exists?
#+begin_src sparql
    PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
    PREFIX org: <http://www.w3.org/ns/org#>
    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
    PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
    PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
    select distinct ?mandataris ?p ?o ?g
    where {
      VALUES (?mandataris ?bestuurseenheid ){
        (<http://data.lblod.info/id/mandatarissen/672354C8AE5F6D098DC0080E> <http://data.lblod.info/id/bestuurseenheden/974816591f269bb7d74aa1720922651529f3d3b2a787f5c60b73e5a0384950a4>)
        (<http://data.lblod.info/id/mandatarissen/bb14b917-df59-4274-9ad4-feed115e072e> <http://data.lblod.info/id/bestuurseenheden/974816591f269bb7d74aa1720922651529f3d3b2a787f5c60b73e5a0384950a4>)
      }
      graph ?g {
        ?mandataris a mandaat:Mandataris .
        ?mandataris ?p ?o .
      }
      ?g ext:ownedBy ?bestuurseenheid .
    }
#+end_src
```


## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/620
