### PR TITLE
Lmb 1802 combined comw and gr for aalst

### DIFF
--- a/config/bb-aalst-ldes/config.ts
+++ b/config/bb-aalst-ldes/config.ts
@@ -1,24 +1,14 @@
-import {
-  LDES_BASE,
-  FIRST_PAGE,
-  TARGET_GRAPH,
-  STATUS_GRAPH,
-  EXTRA_HEADERS,
-  VERSION_PREDICATE,
-  TIME_PREDICATE,
-} from "../environment";
-
 export default {
   endpoints: [
     {
       name: "Public Stream",
-      LDES_BASE,
-      FIRST_PAGE,
-      TARGET_GRAPH,
-      STATUS_GRAPH,
-      EXTRA_HEADERS,
-      VERSION_PREDICATE,
-      TIME_PREDICATE,
+      LDES_BASE: process.env.LDES_BASE,
+      FIRST_PAGE: process.env.FIRST_PAGE,
+      TARGET_GRAPH: process.env.TARGET_GRAPH,
+      STATUS_GRAPH: process.env.STATUS_GRAPH,
+      EXTRA_HEADERS: process.env.EXTRA_HEADERS,
+      VERSION_PREDICATE: process.env.VERSION_PREDICATE,
+      TIME_PREDICATE: process.env.TIME_PREDICATE,
     },
   ],
 };

--- a/config/bb-aalst-ldes/config.ts
+++ b/config/bb-aalst-ldes/config.ts
@@ -1,0 +1,24 @@
+import {
+  LDES_BASE,
+  FIRST_PAGE,
+  TARGET_GRAPH,
+  STATUS_GRAPH,
+  EXTRA_HEADERS,
+  VERSION_PREDICATE,
+  TIME_PREDICATE,
+} from "../environment";
+
+export default {
+  endpoints: [
+    {
+      name: "Public Stream",
+      LDES_BASE,
+      FIRST_PAGE,
+      TARGET_GRAPH,
+      STATUS_GRAPH,
+      EXTRA_HEADERS,
+      VERSION_PREDICATE,
+      TIME_PREDICATE,
+    },
+  ],
+};

--- a/config/bb-aalst-ldes/processPage.ts
+++ b/config/bb-aalst-ldes/processPage.ts
@@ -1,5 +1,5 @@
 import { logger } from "../logger";
-import { updateSudo } from "@lblod/mu-auth-sudo";
+import { updateSudo, querySudo } from "@lblod/mu-auth-sudo";
 import { sparqlEscapeUri } from "mu";
 import {
   BATCH_GRAPH,
@@ -27,18 +27,15 @@ export async function processPage() {
 
   const burgemeesterOrgaanClassificatieCodeUri = 'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4955bd72cd0e4eb895fdbfab08da0284';
   const bekrachtigdPublicatieCodeUri = 'http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/9d8fd14d-95d0-4f5e-b3a5-a56a126227b6';
-
-  await updateSudo(`
+  const commonWhereStatement = (selection: string) => `
     PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
     PREFIX org: <http://www.w3.org/ns/org#>
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
     PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
-    INSERT {
-      GRAPH ?organizationG {
-        ?s ?pNew ?oNew.
-      }
-    } WHERE {
+
+    ${selection}
+    WHERE {
       VALUES ?bestuurseenheid { ${sparqlEscapeUri(GEMEENTE_BESTUURSEENHEID_URI)} }
       
       ?orgaanIT org:hasPost ?mandaat .
@@ -63,5 +60,22 @@ export async function processPage() {
         ?versionedMember ?pNew ?oNew .
         FILTER (?pNew NOT IN ( ${sparqlEscapeUri(VERSION_PREDICATE)}, ${sparqlEscapeUri(TIME_PREDICATE)} ))
       }
-    }`);
+    }
+    `
+
+  const sparqlResult = await querySudo(commonWhereStatement('SELECT DISTINCT ?s'));
+  const foundSubjectUris = sparqlResult.results?.bindings.map((b) => b.s.value) ?? [];
+  if (foundSubjectUris.length >= 1) {
+    logger.info(`Found ${foundSubjectUris.length} subjects for burgemeester-benoemingen. (${foundSubjectUris.join(', ')})`);
+  }
+
+  await updateSudo(commonWhereStatement(`
+    INSERT {
+      GRAPH ?organizationG {
+        ?s ?pNew ?oNew.
+      }
+    }
+  `));
 };
+
+

--- a/config/bb-aalst-ldes/processPage.ts
+++ b/config/bb-aalst-ldes/processPage.ts
@@ -5,7 +5,6 @@ import {
   BATCH_GRAPH,
   VERSION_PREDICATE,
   TIME_PREDICATE,
-  TARGET_GRAPH,
 } from "../environment";
 
 /**
@@ -27,7 +26,8 @@ export async function processPage() {
   logger.debug("Running custom logic to process the current page");
 
   const burgemeesterOrgaanClassificatieCodeUri = 'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4955bd72cd0e4eb895fdbfab08da0284';
-  const bekrachtigdPublicatieCodeUri = 'https://data.lblod.info/id/concept/MandatarisPublicationStatusCode/9d8fd14d-95d0-4f5e-b3a5-a56a126227b6';
+  const bekrachtigdPublicatieCodeUri = 'http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/9d8fd14d-95d0-4f5e-b3a5-a56a126227b6';
+
   await updateSudo(`
     PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
     PREFIX org: <http://www.w3.org/ns/org#>
@@ -44,12 +44,14 @@ export async function processPage() {
       ?orgaanIT org:hasPost ?mandaat .
       ?orgaanIT mandaat:isTijdspecialisatieVan ?orgaan .
       ?orgaan besluit:classificatie | org:classification ${sparqlEscapeUri(burgemeesterOrgaanClassificatieCodeUri)} .
+      ?orgaan besluit:bestuurt ?bestuurseenheid .
 
       FILTER NOT EXISTS {
         GRAPH ?organizationG {
           ?s a mandaat:Mandataris .
         }
       }
+      ?organizationG ext:ownedBy ?bestuurseenheid .
 
       GRAPH ${sparqlEscapeUri(BATCH_GRAPH)} {
         ?stream <https://w3id.org/tree#member> ?versionedMember .
@@ -61,6 +63,5 @@ export async function processPage() {
         ?versionedMember ?pNew ?oNew .
         FILTER (?pNew NOT IN ( ${sparqlEscapeUri(VERSION_PREDICATE)}, ${sparqlEscapeUri(TIME_PREDICATE)} ))
       }
-      ?organizationG ext:ownedBy ?bestuurseenheid .
     }`);
 };

--- a/config/bb-aalst-ldes/processPage.ts
+++ b/config/bb-aalst-ldes/processPage.ts
@@ -3,16 +3,29 @@ import { updateSudo } from "@lblod/mu-auth-sudo";
 import { sparqlEscapeUri } from "mu";
 import {
   BATCH_GRAPH,
-  BYPASS_MU_AUTH,
-  DIRECT_DATABASE_CONNECTION,
   VERSION_PREDICATE,
   TIME_PREDICATE,
   TARGET_GRAPH,
 } from "../environment";
 
+/**
+ * NOTE
+ * This service runs on the locally installed LMB application at the customer site.
+ *
+ * In the **normal flow**, Kalliope pushes the new "burgemeester-benoeming" (mayor) to our **central** LMB application, which then creates the mayor mandate (**mandataris**) and validates/confirms it (**bekrachtigt**).
+ *
+ * Since this is a **local** instance of our application, we cannot ask Kalliope to push the data to all locally managed instances. Therefore, we add this ldes-client service to the app.
+ *
+ * This client service will **fetch** all **validated/confirmed** ("bekrachtigde") mayor mandates from our **central** LMB LDES stream.
+ *
+ * The service focuses on mandates (**mandatarissen**) that are **not yet known** in the locally managed instance. This ensures that when a new mayor mandate is validated (**bekrachtigd**), it flows from the central LMB to the locally managed instance **only once**.
+ *
+ * If this mandate is later changed in the local instance and flows back to central LMB, we don't need to worry about it flowing right back. Since the local instance now **knows** the mandate, it will not be added or updated again by this service.
+ */
 const GEMEENTE_BESTUURSEENHEID_URI = process.env.GEMEENTE_BESTUURSEENHEID_URI || "http://data.lblod.info/id/bestuurseenheden/974816591f269bb7d74aa1720922651529f3d3b2a787f5c60b73e5a0384950a4"; // Gemeente Aalst
-
 export async function processPage() {
+  logger.debug("Running custom logic to process the current page");
+
   const burgemeesterOrgaanClassificatieCodeUri = 'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4955bd72cd0e4eb895fdbfab08da0284';
   const bekrachtigdPublicatieCodeUri = 'https://data.lblod.info/id/concept/MandatarisPublicationStatusCode/9d8fd14d-95d0-4f5e-b3a5-a56a126227b6';
   await updateSudo(`

--- a/config/bb-aalst-ldes/processPage.ts
+++ b/config/bb-aalst-ldes/processPage.ts
@@ -34,13 +34,8 @@ export async function processPage() {
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
     PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
-    DELETE {
-      GRAPH ${sparqlEscapeUri(TARGET_GRAPH)} {
-        ?s ?pOld ?oOld.
-      }
-    }
     INSERT {
-      GRAPH ${sparqlEscapeUri(TARGET_GRAPH)} {
+      GRAPH ?organizationG {
         ?s ?pNew ?oNew.
       }
     } WHERE {
@@ -54,7 +49,6 @@ export async function processPage() {
         GRAPH ?organizationG {
           ?s a mandaat:Mandataris .
         }
-        ?organizationG ext:ownedBy ?bestuurseenheid .
       }
 
       GRAPH ${sparqlEscapeUri(BATCH_GRAPH)} {
@@ -67,10 +61,6 @@ export async function processPage() {
         ?versionedMember ?pNew ?oNew .
         FILTER (?pNew NOT IN ( ${sparqlEscapeUri(VERSION_PREDICATE)}, ${sparqlEscapeUri(TIME_PREDICATE)} ))
       }
-      OPTIONAL {
-        GRAPH ${sparqlEscapeUri(TARGET_GRAPH)} {
-          ?s ?pOld ?oOld.
-        }
-      }
+      ?organizationG ext:ownedBy ?bestuurseenheid .
     }`);
 };

--- a/config/bb-aalst-ldes/processPage.ts
+++ b/config/bb-aalst-ldes/processPage.ts
@@ -1,0 +1,63 @@
+import { logger } from "../logger";
+import { updateSudo } from "@lblod/mu-auth-sudo";
+import { sparqlEscapeUri } from "mu";
+import {
+  BATCH_GRAPH,
+  BYPASS_MU_AUTH,
+  DIRECT_DATABASE_CONNECTION,
+  VERSION_PREDICATE,
+  TIME_PREDICATE,
+  TARGET_GRAPH,
+} from "../environment";
+
+const GEMEENTE_BESTUURSEENHEID_URI = process.env.GEMEENTE_BESTUURSEENHEID_URI || "http://data.lblod.info/id/bestuurseenheden/974816591f269bb7d74aa1720922651529f3d3b2a787f5c60b73e5a0384950a4"; // Gemeente Aalst
+
+export async function processPage() {
+  const burgemeesterOrgaanClassificatieCodeUri = 'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4955bd72cd0e4eb895fdbfab08da0284';
+  const bekrachtigdPublicatieCodeUri = 'https://data.lblod.info/id/concept/MandatarisPublicationStatusCode/9d8fd14d-95d0-4f5e-b3a5-a56a126227b6';
+  await updateSudo(`
+    PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+    PREFIX org: <http://www.w3.org/ns/org#>
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+    PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
+    DELETE {
+      GRAPH ${sparqlEscapeUri(TARGET_GRAPH)} {
+        ?s ?pOld ?oOld.
+      }
+    }
+    INSERT {
+      GRAPH ${sparqlEscapeUri(TARGET_GRAPH)} {
+        ?s ?pNew ?oNew.
+      }
+    } WHERE {
+      VALUES ?bestuurseenheid { ${sparqlEscapeUri(GEMEENTE_BESTUURSEENHEID_URI)} }
+      
+      ?orgaanIT org:hasPost ?mandaat .
+      ?orgaanIT mandaat:isTijdspecialisatieVan ?orgaan .
+      ?orgaan besluit:classificatie | org:classification ${sparqlEscapeUri(burgemeesterOrgaanClassificatieCodeUri)} .
+
+      FILTER NOT EXISTS {
+        GRAPH ?organizationG {
+          ?s a mandaat:Mandataris .
+        }
+        ?organizationG ext:ownedBy ?bestuurseenheid .
+      }
+
+      GRAPH ${sparqlEscapeUri(BATCH_GRAPH)} {
+        ?stream <https://w3id.org/tree#member> ?versionedMember .
+        ?versionedMember ${sparqlEscapeUri(VERSION_PREDICATE)} ?s .
+        ?versionedMember a mandaat:Mandataris .
+        ?versionedMember lmb:hasPublicationStatus ${sparqlEscapeUri(bekrachtigdPublicatieCodeUri)} .
+        ?versionedMember org:holds ?mandaat .
+        ?versionedMember ext:owningBestuurseenheid | ext:relatedTo ?bestuurseenheid .
+        ?versionedMember ?pNew ?oNew .
+        FILTER (?pNew NOT IN ( ${sparqlEscapeUri(VERSION_PREDICATE)}, ${sparqlEscapeUri(TIME_PREDICATE)} ))
+      }
+      OPTIONAL {
+        GRAPH ${sparqlEscapeUri(TARGET_GRAPH)} {
+          ?s ?pOld ?oOld.
+        }
+      }
+    }`);
+};

--- a/config/cl-authorization/config.lisp
+++ b/config/cl-authorization/config.lisp
@@ -294,6 +294,15 @@
           PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
           SELECT ?session_group ?session_role WHERE {
             <SESSION_ID> ext:sessionGroup/mu:uuid ?session_group.
+            BIND(IF(?session_group IN (
+                    \"974816591f269bb7d74aa1720922651529f3d3b2a787f5c60b73e5a0384950a4\",
+                    \"d769b4b9411ad25f67c1d60b0a403178e24a800e1671fb3258280495011d8e18\"
+                  ),
+                  \"aalstCombinedGraph\",
+                  ?session_group
+                )
+                AS ?session_group_mut
+              )
           }")
 
 (grant (read)
@@ -301,25 +310,43 @@
        :for-allowed-group "organization-member")
 
 (supply-allowed-group "mandaat-gebruiker"
-  :parameters ("session_group" "session_role")
+  :parameters ("session_group_mut" "session_role")
   :query "PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
           PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-          SELECT DISTINCT ?session_group ?session_role WHERE {
+          SELECT DISTINCT ?session_group_mut ?session_role WHERE {
             <SESSION_ID> ext:sessionGroup/mu:uuid ?session_group;
                          ext:sessionRole ?session_role.
             FILTER( ?session_role = \"LoketLB-mandaatGebruiker\" )
+            BIND(IF(?session_group IN (
+                    \"974816591f269bb7d74aa1720922651529f3d3b2a787f5c60b73e5a0384950a4\",
+                    \"d769b4b9411ad25f67c1d60b0a403178e24a800e1671fb3258280495011d8e18\"
+                  ),
+                  \"aalstCombinedGraph\",
+                  ?session_group
+                )
+                AS ?session_group_mut
+              )
           }")
 
 (supply-allowed-group "politieraad-lezer"
-  :parameters ("session_group" "session_role")
+  :parameters ("session_group_mut" "session_role")
   :query "PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
           PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-          SELECT DISTINCT ?session_group ?session_role WHERE {
+          SELECT DISTINCT ?session_group_mut ?session_role WHERE {
             <SESSION_ID> ext:sessionGroup ?original_session_group;
                          ext:sessionRole ?session_role.
             ?original_session_group ext:deeltBestuurVan/mu:uuid ?session_group.
 
             FILTER( ?session_role = \"LoketLB-mandaatGebruiker\" )
+            BIND(IF(?session_group IN (
+                    \"974816591f269bb7d74aa1720922651529f3d3b2a787f5c60b73e5a0384950a4\",
+                    \"d769b4b9411ad25f67c1d60b0a403178e24a800e1671fb3258280495011d8e18\"
+                  ),
+                  \"aalstCombinedGraph\",
+                  ?session_group
+                )
+                AS ?session_group_mut
+              )
           }")
 
 (grant (read)

--- a/config/migrations/2026/20260106000000-move-aalst-ocmw-gr-to-same-graph.sparql
+++ b/config/migrations/2026/20260106000000-move-aalst-ocmw-gr-to-same-graph.sparql
@@ -1,0 +1,16 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/> 
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/organizations/aalstCombinedGraph/LoketLB-mandaatGebruiker> {
+    ?s ?p ?o .
+  }
+} WHERE {
+  graph ?g {
+    ?s ?p ?o .
+  }
+  VALUES ?id { "974816591f269bb7d74aa1720922651529f3d3b2a787f5c60b73e5a0384950a4" "d769b4b9411ad25f67c1d60b0a403178e24a800e1671fb3258280495011d8e18" }
+  ?g ext:ownedBy ?eenheid .
+  ?eenheid mu:uuid ?id .
+
+}

--- a/config/migrations/2026/20260106000001-make-aalst-graphs-owned-by.sparql
+++ b/config/migrations/2026/20260106000001-make-aalst-graphs-owned-by.sparql
@@ -1,0 +1,10 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/> 
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://mu.semte.ch/graphs/organizations/aalstCombinedGraph/LoketLB-mandaatGebruiker> ext:ownedBy 	
+    <http://data.lblod.info/id/bestuurseenheden/974816591f269bb7d74aa1720922651529f3d3b2a787f5c60b73e5a0384950a4>, 	
+    <http://data.lblod.info/id/bestuurseenheden/d769b4b9411ad25f67c1d60b0a403178e24a800e1671fb3258280495011d8e18> ,
+    <http://mu.semte.ch/graphs/organizations/aalstCombinedGraph> .
+  }
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -127,3 +127,8 @@ services:
     restart: "no"
   locally-managed-ldes-client:
     restart: "no"
+  bb-aalst-ldes-client:
+    restart: "no"
+    environment:
+      RUN_AT_STARTUP: false
+      LOG_LEVEL: info # error, warn, info, verbose, debug, or silly. Default: info

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -269,6 +269,8 @@ services:
       - "./data/ldes-feed/:/data/"
   decision-ldes-client:
     image: lblod/ldes-client:0.0.3
+    profiles:
+      - isDisabledOnLocalSetup
     links:
       - database:database
       - virtuoso:virtuoso
@@ -290,6 +292,8 @@ services:
   ##############################################################################
   vendor-login:
     image: lblod/vendor-login-service:1.3.0
+    profiles:
+      - isDisabledOnLocalSetup
     restart: always
     labels:
       - "logging=true"
@@ -325,6 +329,8 @@ services:
     logging: *default-logging
   vendor-management-consumer:
     image: lblod/delta-consumer:0.0.26
+    profiles:
+      - isDisabledOnLocalSetup
     environment:
       DCR_SERVICE_NAME: "vendor-management-consumer"
       DCR_SYNC_BASE_URL: "https://dev.loket.lblod.info/"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -392,3 +392,20 @@ services:
     labels:
       - "logging=true"
     logging: *default-logging
+  bb-aalst-ldes-client:
+    image: lblod/ldes-client:0.0.3
+    volumes:
+    - ./config/bb-aalst-ldes:/config
+    restart: always
+    environment:
+      CRON_PATTERN: "3 * * * *" # Every hour at minute 3
+      LDES_BASE: https://mandatenbeheer.lblod.info/streams/ldes/public/
+      FIRST_PAGE: https://mandatenbeheer.lblod.info/streams/ldes/public/1
+      TARGET_GRAPH: http://mu.semte.ch/graphs/aalst-bb-lmb-consumed
+      WORKING_GRAPH: http://mu.semte.ch/graphs/aalst-bb-lmb-consumed-tmp
+      DIRECT_DATABASE_CONNECTION: 'http://virtuoso:8890/sparql'
+      RANDOMIZE_GRAPHS: true
+      BATCH_SIZE: 100
+    labels:
+      - "logging=true"
+    logging: *default-logging


### PR DESCRIPTION
## Description

We want Aalst logged in user to see both OWCM & GR data in their application.

## How to test

1. Run the migrations
2. Kill resource & cache if you ran the frontend already
3. Test out the frontend, it should show all options  for OCMW & GR in the dropdown + mirroring between ocmw and gr

## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/480 **BASE PR**
