### PR TITLE
LMB-1867 | Release v1.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.1.9 (2026-04-01)
+
+### :house: Internal
+ - Bumped mandataris-service to v0.9.8
+ - Bumped frontend to v0.9.9
+ - Bumped ldes-delta-pusher to v1.2.13
+ - Fix Ldes content publish
+
+### :rocket: Enhancement
+  - Unlink mandate before linking 
+  - Fix datetime of mandate data in Dessel (ocmw/gemeente) 
+
 ## 1.1.8 (2026-03-13)
 
 ### :house: Internal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,7 @@ services:
     restart: always
     logging: *default-logging
   frontend:
-    image: lblod/frontend-lokaal-mandatenbeheer:0.9.8
+    image: lblod/frontend-lokaal-mandatenbeheer:0.9.9
     labels:
       - "logging=true"
     restart: always
@@ -143,7 +143,7 @@ services:
     volumes:
       - ./config/form-content:/config
   mandataris:
-    image: lblod/mandataris-service:0.9.7
+    image: lblod/mandataris-service:0.9.8
     labels:
       - "logging=true"
     restart: always


### PR DESCRIPTION
## Description

Release a new version of the app
- mandataris service (linking)
- frontend (feature flags)
- ldes-delta-pusher bump
- ldes content filter fixed (graph)

## How to test

1. all images are published
2. app is working

## Links to other PR's

- https://github.com/lblod/mandataris-service/pull/137
- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/629
