### PR TITLE
chore: bump sparql-parser to v0.0.15

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -39,7 +39,7 @@ services:
       - default
       - debug
   database:
-    image: semtech/sparql-parser:feature-ordered-data-modification-queries
+    # image: semtech/sparql-parser:feature-ordered-data-modification-queries
     restart: "no"
     networks:
       - default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     restart: always
     logging: *default-logging
   database:
-    image: semtech/sparql-parser:0.0.14
+    image: semtech/sparql-parser:0.0.15
     environment:
       MU_SPARQL_ENDPOINT: "http://virtuoso:8890/sparql"
       DATABASE_OVERLOAD_RECOVERY: "true"


### PR DESCRIPTION
## Description

The ticket titel states: check sparql-parser version and bump if needed. I see that our current version is `v0.0.14` which is fine (1 year old). I bumped it to `v0.0.15` to be the latest. In this version they process queries differently (quote Erika "sparql-parser v0.0.15 starts using CONSTRUCT queries under the hood")

Not completely convinced to do this version bump. As in Open Proces Huis there is an issue that it can only write to a single graph, we do not do that in LMB (if i looked at the code) so normally if thats the only bug it should be fine. (contradictory I know)
When looking at the other apps in LBLOD some are using it so I assume we should be save https://github.com/search?q=org%3Alblod%20parser%3A0.0.15&type=code


=> We could do the bump 

## How to test

1. Go over the frontend application and see if all values are written
2. Our external services like mandataris etc should also be able to write to the database without a problem
3. I also checked limburg for the eigen gevenens but looks good

