### PR TITLE
LMB-1919 | remove sterfdatum library field with complex path + add with simple path

### DIFF
--- a/config/migrations/2026/20260623170000-remove-sterf-library-field.sparql
+++ b/config/migrations/2026/20260623170000-remove-sterf-library-field.sparql
@@ -1,0 +1,37 @@
+delete {
+  graph ?g {
+    ?field ?p ?o .
+    ?form <http://lblod.data.gift/vocabularies/forms/includes> ?field .
+  }
+}
+where {
+  graph ?g {
+    ?field ?fp <http://data.lblod.info/id/lmb/form-library-entries/0bdd360b-c6e5-46d9-9a31-8645a4c5774c> .
+    ?field ?p ?o .
+    optional {
+      ?form <http://lblod.data.gift/vocabularies/forms/includes> ?field .
+    }
+  }
+}
+
+;
+
+delete {
+  graph ?g {
+    ?s ?p ?o .
+  } 
+}
+where {
+  values ?s {
+    <http://data.lblod.info/id/lmb/form-library-entries/0bdd360b-c6e5-46d9-9a31-8645a4c5774c>
+    <http://data.lblod.info/id/lmb/paths/574867d1-3422-41a9-8648-34dc2c443204> 
+    <http://data.lblod.info/id/lmb/paths/0c65e9c8-0910-490a-96e7-19b71290b91a>
+    <http://data.lblod.info/id/lmb/shapes/d56503fc-96d4-49fc-8425-e36db36fd172> 
+    <http://data.lblod.info/id/lmb/shapes/048663a1-6b73-4346-8267-0f40e0dff9f4> 
+    <http://data.lblod.info/id/lmb/generators/3afc0fad-e475-4696-ae50-3627fed41cf8>
+  }
+  graph ?g {
+    ?s ?p ?o .
+  } 
+}
+

--- a/config/migrations/2026/20260623170001-add-sterf-library-field-with-simple-path.sparql
+++ b/config/migrations/2026/20260623170001-add-sterf-library-field-with-simple-path.sparql
@@ -1,0 +1,15 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX form: <http://lblod.data.gift/vocabularies/forms/>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/lmb/form-library-entries/0bdd360b-c6e5-46d9-9a31-8645a4c5774c> a ext:FormLibraryEntry ;
+     mu:uuid "0bdd360b-c6e5-46d9-9a31-8645a4c5774c" ;
+     sh:name "Sterfdatum" ;
+     form:displayType <http://lblod.data.gift/display-types/lmb/custom-date-input> ;
+     sh:path ext:sterfDatum ;
+     sh:order 1000 .
+  }
+}


### PR DESCRIPTION
## Description

As the complex paths are broken in the form-content service we will be removing the library field with the complex path and adding the same but with  a simple path


## How to test

1. Migrations ran
2. When adding the field in the frontend it has a simple path

## Links to other PR's

- https://github.com/lblod/form-content-service/pull/91

## Attachments

**ext:sterfDatum**
<img width="720" height="640" alt="image" src="https://github.com/user-attachments/assets/d8d84383-7c21-4729-b72e-868fcb4aab22" />
