### PR TITLE
fetch start and end dates from op too

### DIFF
--- a/config/op-consumer/mapping/queries/op2dl/pass/pass-without-lmb-properties.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/pass/pass-without-lmb-properties.sparql
@@ -26,8 +26,6 @@ WHERE {
     <http://mu.semte.ch/vocabularies/ext/origineleBestuursorgaan>,
     <http://lblod.data.gift/vocabularies/lmb/heeftBestuursperiode>,
     <http://mu.semte.ch/vocabularies/ext/deeltBestuurVan>,
-    <http://lblod.data.gift/vocabularies/lmb/faciliteitenGemeente>,
-    <http://data.vlaanderen.be/ns/mandaat#bindingStart>, # Adding bindingStart & bindingEinde to this list as these values.. 
-    <http://data.vlaanderen.be/ns/mandaat#bindingEinde> # are set by the first mandataris start date in the period
+    <http://lblod.data.gift/vocabularies/lmb/faciliteitenGemeente>
   ))
 }

--- a/config/op-consumer/mapping/queries/op2dl/pass/pass-without-voorzitter-bestuursorgaan-codes.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/pass/pass-without-voorzitter-bestuursorgaan-codes.sparql
@@ -4,7 +4,7 @@ CONSTRUCT {
 }
 WHERE {
   ?bestuursorgaan a <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan> .
-  ?bestuursorgaan <http://data.vlaanderen.be/ns/besluit#classificatie> ?classificationCode .
+  ?bestuursorgaan <https://data.vlaanderen.be/ns/generiek#isTijdspecialisatieVan>? / (<http://data.vlaanderen.be/ns/besluit#classificatie> | <http://www.w3.org/ns/org#classification>) ?classificationCode .
   ?bestuursorgaan ?p ?o .
 
   FILTER(?classificationCode NOT IN(
@@ -28,9 +28,7 @@ WHERE {
     <http://mu.semte.ch/vocabularies/ext/origineleBestuursorgaan>,
     <http://lblod.data.gift/vocabularies/lmb/heeftBestuursperiode>,
     <http://mu.semte.ch/vocabularies/ext/deeltBestuurVan>,
-    <http://lblod.data.gift/vocabularies/lmb/faciliteitenGemeente>,
-    <http://data.vlaanderen.be/ns/mandaat#bindingStart>, # Adding bindingStart & bindingEinde to this list as these values.. 
-    <http://data.vlaanderen.be/ns/mandaat#bindingEinde> # are set by the first mandataris start date in the period
+    <http://lblod.data.gift/vocabularies/lmb/faciliteitenGemeente>
   ))
 }
 


### PR DESCRIPTION
## Description

allows the delta consumer to update binding start and einde from op.
Fixes it not listening for changes to bestuurorgaan in tijd

## How to test

Remove all tasks and jobs:
```
  PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
  PREFIX dct: <http://purl.org/dc/terms/>
    DELETE WHERE {
      GRAPH ?g {
  ?s a task:Task .
      ?s ?sp ?so.
    ?s dct:isPartOf ?job.
      ?job ?jobp ?jobo.
        }
    }
```
Remove the start time from this org: 
```
  PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
  DELETE {
    GRAPH ?g {
      ?org mandaat:bindingStart ?old .
    }
  }
  WHERE {
    VALUES ?org {
      <http://data.lblod.info/id/bestuursorganen/281b5474-0f6d-4ac8-94ef-55afd338d3f8>
    }
    GRAPH ?g {
      ?org mandaat:bindingStart ?old .
    }
    FILTER(?g NOT IN (<http://mu.semte.ch/graphs/landing-zone/op-public>))

  }
```
Run the delta consumer locally with a start time set to 1AM today and use the test env from op: https://organisaties.abb.lblod.info/
See the OP date being set in the org

