### PR TITLE
follow OP start and end dates, with or without timezone, also bump migrations so we have mu script migrations new

### DIFF
--- a/config/migrations/20260713132225-accept-op-start-end-dates.sparql
+++ b/config/migrations/20260713132225-accept-op-start-end-dates.sparql
@@ -1,0 +1,38 @@
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s mandaat:bindingStart ?old.
+  }
+}
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s mandaat:bindingStart ?new.
+  }
+}WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s mandaat:bindingStart ?old.
+  }
+  GRAPH <http://mu.semte.ch/graphs/landing-zone/op-public> {
+    ?s mandaat:bindingStart ?new.
+  }
+  FILTER (?old != ?new)
+};
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s mandaat:bindingEinde ?old.
+  }
+}
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s mandaat:bindingEinde ?new.
+  }
+}WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s mandaat:bindingEinde ?old.
+  }
+  GRAPH <http://mu.semte.ch/graphs/landing-zone/op-public> {
+    ?s mandaat:bindingEinde ?new.
+  }
+  FILTER (?old != ?new)
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
     restart: always
     logging: *default-logging
   migrations:
-    image: semtech/mu-migrations-service:0.6.0
+    image: semtech/mu-migrations-service:0.9.0
     links:
       - virtuoso:database
     environment:
@@ -323,11 +323,14 @@ services:
       DCR_SYNC_BASE_URL: "https://dev.loket.lblod.info/"
       DCR_SYNC_FILES_PATH: "/sync/vendor-management/files"
       DCR_JOB_CREATOR_URI: "http://data.lblod.info/services/id/vendor-management-consumer"
-      DCR_SYNC_DATASET_SUBJECT: "http://data.lblod.info/datasets/delta-producer/dumps\
+      DCR_SYNC_DATASET_SUBJECT:
+        "http://data.lblod.info/datasets/delta-producer/dumps\
         /VendorManagementCacheGraphDump"
-      DCR_INITIAL_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/Job\
+      DCR_INITIAL_SYNC_JOB_OPERATION:
+        "http://redpencil.data.gift/id/jobs/concept/Job\
         Operation/deltas/consumer/initialSync/vendor-management"
-      DCR_DELTA_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOp\
+      DCR_DELTA_SYNC_JOB_OPERATION:
+        "http://redpencil.data.gift/id/jobs/concept/JobOp\
         eration/deltas/consumer/VendorManagementFileSyncing"
       INGEST_GRAPH: "http://mu.semte.ch/graphs/automatic-submission"
       DCR_DISABLE_INITIAL_SYNC: "true"
@@ -347,11 +350,14 @@ services:
     environment:
       DCR_SERVICE_NAME: "op-public-consumer"
       DCR_SYNC_FILES_PATH: "/sync/public/files"
-      DCR_SYNC_DATASET_SUBJECT: "http://data.lblod.info/datasets/delta-producer/dumps\
+      DCR_SYNC_DATASET_SUBJECT:
+        "http://data.lblod.info/datasets/delta-producer/dumps\
         /PublicCacheGraphDump"
-      DCR_INITIAL_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/Job\
+      DCR_INITIAL_SYNC_JOB_OPERATION:
+        "http://redpencil.data.gift/id/jobs/concept/Job\
         Operation/deltas/consumer/initialSync/op-public"
-      DCR_DELTA_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOp\
+      DCR_DELTA_SYNC_JOB_OPERATION:
+        "http://redpencil.data.gift/id/jobs/concept/JobOp\
         eration/deltas/consumer/deltaSync/op-public"
       DCR_JOB_CREATOR_URI: "http://data.lblod.info/services/id/op-public-consumer"
       DCR_DISABLE_INITIAL_SYNC: "false"


### PR DESCRIPTION
## Description

This follows the OP bindingstart and end dates. 
It also bumps the migraitons service so we have the `mu script migrations new` command to generate migration files

## How to test
start from recent prod data
before:
```
  PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
  SELECT ?label ?one ?two WHERE {
    GRAPH <http://mu.semte.ch/graphs/public> {
      ?s mandaat:bindingStart ?one.
    }
    GRAPH <http://mu.semte.ch/graphs/landing-zone/op-public> {
      ?s mandaat:bindingStart ?two.
    }
    FILTER (?one != ?two)

    ?s mandaat:isTijdspecialisatieVan / skos:prefLabel ?label.
  }
```
and its corresponding bindingEinde (left as an exercise to the reader) return results.
Notice that when editing mandatarissen in an affected prod unit (e.g. deputatie limburg), the application doesn't care about there being two startdates, this means that this is not a high prio PR.
After running the included migration, this query doesn't return results anymore.
You can also still edit mandatarissen in the UI after this and the limits to start/enddates still apply.